### PR TITLE
Strip HTML when printing ToC and generating IDs

### DIFF
--- a/ocfweb/component/markdown.py
+++ b/ocfweb/component/markdown.py
@@ -2,6 +2,7 @@ import re
 
 import mistune
 from django.core.urlresolvers import reverse
+from django.utils.html import strip_tags
 
 from ocfweb.caching import lru_cache
 
@@ -118,7 +119,7 @@ class HeaderRendererMixin:
         else:
             id = 'h{level}_{title}'.format(
                 level=level,
-                title=re.sub('[^a-z0-9\-_ ]', '', text.lower()).strip().replace(' ', '-'),
+                title=re.sub('[^a-z0-9\-_ ]', '', strip_tags(text).lower()).strip().replace(' ', '-'),
             )
 
             # dumb collision avoidance

--- a/ocfweb/docs/templatetags/docs.py
+++ b/ocfweb/docs/templatetags/docs.py
@@ -3,6 +3,7 @@ from collections import namedtuple
 from operator import attrgetter
 
 from django import template
+from django.utils.html import strip_tags
 
 from ocfweb.docs.urls import DOCS
 
@@ -69,7 +70,7 @@ def doc_toc(toc):
                 cur += 1
             html += '<li><a href="#{fragment}">{text}</a></li>'.format(
                 fragment=id,
-                text=text,
+                text=strip_tags(text),
             )
 
         while cur > levels[0]:


### PR DESCRIPTION
This fixes #44 