### PR TITLE
Fix staff hours head spacing

### DIFF
--- a/ocfweb/main/templates/home.html
+++ b/ocfweb/main/templates/home.html
@@ -95,11 +95,13 @@
                             <span class="cancelled-text">cancelled this week</span>
                         {% endif %}
                     </p>
-                    <ul class="ocf-staffhours-faces">
+                    <div class="ocf-staffhours-faces">
+                      <!--
                         {% for staffer in staff_hour.staff %}
-                            <li><img alt="{{staffer.user_name}}" src="{{staffer|gravatar:77}}" /></li>
+                            --><img alt="{{staffer.user_name}}" src="{{staffer|gravatar:77}}" /><!--
                         {% endfor %}
-                    </ul>
+                      -->
+                    </div>
                 </div>
             {% endfor %}
 

--- a/ocfweb/static/scss/pages/home.scss
+++ b/ocfweb/static/scss/pages/home.scss
@@ -59,11 +59,8 @@
         .ocf-staffhours-faces {
             @extend .list-inline;
 
-            // squeeze closer on phones to try to fit them on a single line
-            @media (max-width: 767px) {
-                li {
-                    padding: 0;
-                }
+            li {
+                padding: 0;
             }
         }
 

--- a/ocfweb/static/scss/pages/home.scss
+++ b/ocfweb/static/scss/pages/home.scss
@@ -57,10 +57,11 @@
         }
 
         .ocf-staffhours-faces {
-            @extend .list-inline;
-
-            li {
-                padding: 0;
+            @media (min-width: 768px) {
+                img {
+                    margin-right: 10px;
+                    margin-bottom: 10px;
+                }
             }
         }
 


### PR DESCRIPTION
We were double padding since Bootstrap pads list items by default.

https://github.com/twbs/bootstrap-sass/blob/master/assets/stylesheets/bootstrap/_type.scss#L179

```css
// Inline turns list items into inline-block
.list-inline {
  @include list-unstyled;
  margin-left: -5px;

  > li {
    display: inline-block;
    padding-left: 5px;
    padding-right: 5px;
  }
}
```
![screenshot - 10022015 - 02 03 09 pm](https://cloud.githubusercontent.com/assets/6722367/10257812/59177fe8-690e-11e5-8562-cfd2f7ddfa40.png)
