### PR TITLE
Fix heading anchor link icon size

### DIFF
--- a/ocfweb/static/scss/pages/docs.scss
+++ b/ocfweb/static/scss/pages/docs.scss
@@ -32,4 +32,16 @@
             }
         }
     }
+
+    h4 .anchor {
+        font-size: 16px;
+    }
+
+    h5 .anchor {
+        font-size: 13px;
+    }
+
+    h6 .anchor {
+        font-size: 10px;
+    }
 }


### PR DESCRIPTION
Even on the useless h5 and h6.

![screenshot - 10042015 - 04 29 52 pm](https://cloud.githubusercontent.com/assets/6722367/10270910/52da08aa-6ab5-11e5-8a5f-38f9e504f496.png)

![screenshot - 10042015 - 04 34 09 pm](https://cloud.githubusercontent.com/assets/6722367/10270947/0ffdaa22-6ab6-11e5-9346-964bb30fb184.png)
