### PR TITLE
Open services dropdown on hover

### DIFF
--- a/ocfweb/static/scss/site.scss
+++ b/ocfweb/static/scss/site.scss
@@ -80,6 +80,12 @@ h6 {
             font-size: 14px;
         }
     }
+
+    .dropdown:hover .dropdown-menu {
+        @media (min-width: 768px) {
+            display: block;
+        }
+    }
 }
 
 .ocf-status-bar {


### PR DESCRIPTION
Hovering only opens the dropdown, while clicking activates the link and holds the dropdown open while it has focus. The behavior seems consistent enough to be usable.