### PR TITLE
Use open style on dropdown nav item on hover

### DIFF
--- a/ocfweb/static/scss/site.scss
+++ b/ocfweb/static/scss/site.scss
@@ -81,9 +81,19 @@ h6 {
         }
     }
 
-    .dropdown:hover .dropdown-menu {
-        @media (min-width: 768px) {
-            display: block;
+    @media (min-width: 768px) {
+        .dropdown:hover {
+            > a,
+            > a:hover {
+                // styles copied from .open > a
+                // (unfortunately, can't @extend inside a media query)
+                background-color: #e7e7e7;
+                color: #555;
+            }
+
+            .dropdown-menu {
+                display: block;
+            }
         }
     }
 }


### PR DESCRIPTION
Follow-up to @matthew-mcallister's #62 

This gives us the same "open" styling as when clicking if you hover:

![](http://i.fluffy.cc/GJwjDvnXfM32QWC8WS7TR4NNDk65Nfhz.png)