### PR TITLE
Add "Edit this Page" link at bottom of Markdown docs

### DIFF
--- a/ocfweb/docs/doc.py
+++ b/ocfweb/docs/doc.py
@@ -25,3 +25,12 @@ class Document(namedtuple('Document', ['name', 'title', 'render'])):
             return self.name + '/'
         else:
             return self.category
+
+    @property
+    def edit_url(self):
+        """Return a GitHub edit URL for this page."""
+        return (
+            'https://github.com/ocf/ocfweb/edit/master/ocfweb/docs/docs' +
+            self.name +
+            '.md'
+        )

--- a/ocfweb/docs/templates/doc.html
+++ b/ocfweb/docs/templates/doc.html
@@ -9,6 +9,15 @@
         {% endblock %}
         {{html|safe}}
         {% block after-content %}{% endblock %}
+        {% block page-footer %}
+            <hr />
+            <p>
+                <a class="edit-this-page" href="{{doc.edit_url}}">
+                    <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
+                    Edit this Page
+                </a>
+            </p>
+        {% endblock %}
     </div>
 
     <div class="col-sm-4 ocf-sidebar">

--- a/ocfweb/docs/templates/doc.html
+++ b/ocfweb/docs/templates/doc.html
@@ -9,19 +9,17 @@
         {% endblock %}
         {{html|safe}}
         {% block after-content %}{% endblock %}
-        {% block page-footer %}
-            <hr />
+    </div>
+
+    <div class="col-sm-4 ocf-sidebar">
+        {% block sidebar %}
             <p>
                 <a class="edit-this-page" href="{{doc.edit_url}}">
                     <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
                     Edit this Page
                 </a>
             </p>
-        {% endblock %}
-    </div>
-
-    <div class="col-sm-4 ocf-sidebar">
-        {% block sidebar %}
+            <hr class="edit-page-border" />
             {% doc_toc toc=toc %}
 
             <h3>More in this category</h3>

--- a/ocfweb/static/scss/pages/docs.scss
+++ b/ocfweb/static/scss/pages/docs.scss
@@ -44,6 +44,10 @@
     h6 .anchor {
         font-size: 10px;
     }
+
+    .edit-this-page .glyphicon {
+        font-size: 12px;
+    }
 }
 
 .doc-collapse-toggle {

--- a/ocfweb/static/scss/pages/docs.scss
+++ b/ocfweb/static/scss/pages/docs.scss
@@ -45,8 +45,25 @@
         font-size: 10px;
     }
 
-    .edit-this-page .glyphicon {
-        font-size: 12px;
+    .edit-this-page {
+        display: block;
+        padding: 5px;
+        font-size: 13px;
+
+        &:hover {
+            background-color: #f7f7f7;
+            text-decoration: none;
+        }
+
+        .glyphicon {
+            font-size: 10px;
+            margin-left: 5px;
+            margin-right: 2px;
+        }
+    }
+
+    .edit-page-border {
+        margin-top: 0;
     }
 }
 


### PR DESCRIPTION
This closes #14 

This makes it a little easier for staff to make quick edits, and also suggests to random visitors that their contributions are welcome (as unlikely as they might be to make them).

If you try to make edits without having write access to the repo, you'll be lead through forking the repo and then submitting a pull request.

![](http://i.fluffy.cc/mTQznrwvn14w1lGwsQbpnLvRfdFzdkTn.png)