### PR TITLE
Offset anchors on docs

### DIFF
--- a/ocfweb/static/scss/pages/docs.scss
+++ b/ocfweb/static/scss/pages/docs.scss
@@ -16,6 +16,16 @@
             display: inline;
         }
 
+
+        // hack to make anchors jump to 60px above the actual header so that
+        // they aren't blocked by the fixed OCF navbar
+        &:before {
+            content: '';
+            display: block;
+            height: 60px; // height of ocf navbar
+            margin-top: -60px; // negative navbar height
+        }
+
         .anchor {
             display: none;
             font-size: 18px;


### PR DESCRIPTION
Previously anchors would take you to the header exactly, but the 60px fixed OCF navbar would cover the heading.

before:
![](http://i.fluffy.cc/gCW978QtWpd3JGWRtztsvmD9WzQcT0Wk.png)

after:
![](http://i.fluffy.cc/Km7T1NjfTNm1PPN6fHBfs7JXlBffBhF7.png)

This hacks an empty block before it to offset it. It doesn't affect how the page looks at all, but makes the anchors behave properly.