### PR TITLE
Fix lab utilization numbers

### DIFF
--- a/ocfweb/stats/templates/summary.html
+++ b/ocfweb/stats/templates/summary.html
@@ -66,7 +66,11 @@
                     <td>{{profile.hostname}}</td>
                     <td>{{profile.minutes_idle|floatformat:"0"}}</td>
                     <td>{{profile.minutes_busy|floatformat:"0"}}</td>
-                    <td>{{profile.minutes_busy|div:profile.total_minutes|mul:100|floatformat:"0"}}%</td>
+                    {% if profile.total_minutes <= 0 %}
+                        <td>0%</td>
+                    {% else %}
+                        <td>{{profile.minutes_busy|div:profile.total_minutes|mul:100|floatformat:"0"}}%</td>
+                    {% endif %}
                 </tr>
             {% endfor %}
         </table>


### PR DESCRIPTION
Use the current time as the ending time for lab utilization stats if the lab has not closed yet to give accurate idle, busy and percentage usage values for a day. Also make sure the percentage isn't negative if the lab hasn't opened yet for a day.

I definitely haven't been here for 461 minutes today, I swear...

![way-too-long](https://cloud.githubusercontent.com/assets/1523594/11455017/50b22518-95fc-11e5-83de-f548c4048230.png)