### PR TITLE
stats: add basic printing numbers

### DIFF
--- a/ocfweb/stats/summary.py
+++ b/ocfweb/stats/summary.py
@@ -5,6 +5,9 @@ from operator import attrgetter
 from django.shortcuts import render_to_response
 from django.template import RequestContext
 from ocflib.constants import CURRENT_SEMESTER_START
+from ocflib.lab.printing import get_maintkit
+from ocflib.lab.printing import get_toner
+from ocflib.lab.printing import PRINTERS
 from ocflib.lab.stats import list_desktops
 from ocflib.lab.stats import staff_in_lab
 from ocflib.lab.stats import STATS_EPOCH
@@ -45,6 +48,10 @@ def summary(request):
             'top_staff_alltime': top_staff_alltime()[:10],
             'top_staff_semester': top_staff_semester()[:10],
             'users_in_lab_count': users_in_lab_count(),
+            'printers': sorted(
+                (printer, get_toner(printer), get_maintkit(printer))
+                for printer in PRINTERS
+            ),
         },
         context_instance=RequestContext(request),
     )

--- a/ocfweb/stats/templates/summary.html
+++ b/ocfweb/stats/templates/summary.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
+{% load common %}
 {% load mathfilters %}
+{% load ui_components %}
 
 {% block content %}
     <div class="ocf-content-block">
@@ -17,6 +19,22 @@
                 {% endfor %}
             </ul>
         {% endif %}
+
+        <h3>Printers</h3>
+        {% for printer, toner, maintkit in printers %}
+            <h4>{{printer}}</h4>
+
+            <div class="row">
+                <div class="col-sm-6">
+                    <p><strong>Toner: </strong> {{toner|getitem:0}} pages remaining</p>
+                    {% progress_bar label='' value=toner|getitem:0 max=toner|getitem:1 %}
+                </div>
+                <div class="col-sm-6">
+                    <p><strong>Maintenance Kit: </strong> {{maintkit|getitem:0}} pages remaining</p>
+                    {% progress_bar label='' value=maintkit|getitem:0 max=maintkit|getitem:1 %}
+                </div>
+            </div>
+        {% endfor %}
 
         <h3>Top Staff</h3>
         <h4>This Semester</h4>

--- a/ocfweb/templates/partials/progress-bar.html
+++ b/ocfweb/templates/partials/progress-bar.html
@@ -1,0 +1,5 @@
+<div class="progress">
+    <div class="progress-bar" role="progressbar" aria-valuenow="{{value}}" aria-valuemin="0" aria-valuemax="{{max}}" style="width: {{percent}}%;">
+        {{label}}
+    </div>
+</div>

--- a/ocfweb/templatetags/ui_components.py
+++ b/ocfweb/templatetags/ui_components.py
@@ -1,0 +1,25 @@
+from django import template
+
+register = template.Library()
+
+
+@register.inclusion_tag('partials/progress-bar.html')
+def progress_bar(label, value, max):
+    """Render a Bootstrap progress bar.
+
+    :param label:
+    :param value:
+    :param max:
+
+    Example usage:
+        {% progress_bar label='Toner: 448 pages remaining' value=448 max=24000 %}
+    """
+
+    print(value)
+
+    return {
+        'label': label,
+        'percent': int((value / max) * 100),
+        'value': value,
+        'max': max,
+    }


### PR DESCRIPTION
![](http://i.fluffy.cc/28MBlT6d6R5CvJvPs6Pv2q9DbqCNZNm4.png)

Unfortunately text on Bootstrap progress bars is unreadable when the bars get too short, so I just left the labels blank. I think it still looks kinda reasonable though...

On small screens (phones) they're in the same column which still looks fine:

![](http://i.fluffy.cc/7SFwQxqSJrqLs0NDCPTvjRW98VcwKZt1.png)