### PR TITLE
Add start of periodic functions

### DIFF
--- a/ocfweb/bin/run_periodic_functions.py
+++ b/ocfweb/bin/run_periodic_functions.py
@@ -1,0 +1,36 @@
+import logging
+import os
+from argparse import ArgumentParser
+
+from ocfweb.caching import periodic_functions
+
+
+_logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+def run_periodic_functions(grace_period):
+    # First, import urls so that views are imported, decorators are run, and
+    # our periodic functions get registered.
+    import ocfweb.urls  # noqa
+
+    for pf in periodic_functions:
+        if pf.seconds_since_last_update() >= pf.period - grace_period:
+            pf.update()
+            _logger.info('Updating periodic function: {}'.format(pf))
+        else:
+            _logger.info('Not updating periodic function: {}'.format(pf))
+
+
+def main(argv=None):
+    os.environ['DJANGO_SETTINGS_MODULE'] = 'ocfweb.settings'
+
+    parser = ArgumentParser(description='Run ocfweb periodic functions')
+    parser.add_argument('-g', '--grace-period', type=int, default=5)
+    args = parser.parse_args(argv)
+
+    run_periodic_functions(args.grace_period)
+
+
+if __name__ == '__main__':
+    exit(main())

--- a/ocfweb/caching.py
+++ b/ocfweb/caching.py
@@ -1,10 +1,37 @@
 """Caching decorators for ocfweb."""
+import logging
+from collections import namedtuple
+from datetime import datetime
 from itertools import chain
 
+from cached_property import cached_property
 from django.conf import settings
 from django.core.cache import cache as django_cache
 
 from ocfweb.environment import ocfweb_version
+
+
+_logger = logging.getLogger(__name__)
+
+
+def cache_lookup(key):
+    """Look up a key in the cache, raising KeyError if it's a miss."""
+    # The "get" method returns `None` both for cached values of `None`,
+    # and keys which aren't in the cache.
+    #
+    # The recommended workaround is using a sentinel as a default
+    # return value for when a key is missing. This allows us to still
+    # cache functions which return None.
+    cache_miss_sentinel = {}
+    retval = django_cache.get(key, cache_miss_sentinel)
+    is_hit = retval is not cache_miss_sentinel
+
+    if not is_hit:
+        _logger.debug('Cache miss: {}'.format(key))
+        raise KeyError('Key "{}" is not in the cache.'.format(key))
+    else:
+        _logger.debug('Cache hit: {}'.format(key))
+        return retval
 
 
 def cache_lookup_with_fallback(key, fallback, ttl=None, force_miss=False):
@@ -24,21 +51,18 @@ def cache_lookup_with_fallback(key, fallback, ttl=None, force_miss=False):
     :param force_miss: whether to force a cache miss (and thus evaluate the
                        fallback and store it in the cache)
     """
-    # The "get" method returns `None` both for cached values of `None`,
-    # and keys which aren't in the cache.
-    #
-    # The recommended workaround is using a sentinel as a default
-    # return value for when a key is missing. This allows us to still
-    # cache functions which return None.
-    cache_miss_sentinel = {}
-    retval = django_cache.get(key, cache_miss_sentinel)
-    is_hit = retval is not cache_miss_sentinel
+    try:
+        if force_miss:
+            raise KeyError('Forcing miss as requested.')
 
-    if is_hit and not settings.DEBUG and not force_miss:
-        # cache hit
-        return retval
-    else:
-        # cache miss
+        result = cache_lookup(key)
+
+        if settings.DEBUG:
+            _logger.debug('Cache hit for "{}", but forcing miss due to DEBUG.'.format(key))
+            raise KeyError('Forcing miss due to DEBUG mode.')
+
+        return result
+    except KeyError:
         result = fallback()
         django_cache.set(key, result, ttl)
         return result
@@ -49,6 +73,10 @@ def cache(ttl=None):
 
     The optional ttl (in seconds) specifies how long cache entries should live.
     If not specified, cache entries last until the site rolls.
+
+    If you find yourself using the TTL for anything other than to control the
+    cache size (e.g. because your entries become stale), consider using the
+    @periodic decorator below instead.
 
     Uses the Django cache (which uses Redis) to achieve a shared cache across
     worker processes.
@@ -106,3 +134,124 @@ def _make_function_call_key(fn, args, kwargs):
         tuple(args),
         tuple((k, v) for k, v in sorted(kwargs.items())),
     ))
+
+
+periodic_functions = set()
+
+
+class PeriodicFunction(namedtuple('PeriodicFunction', [
+    'function',
+    'period',
+    'ttl',
+])):
+
+    def __hash__(self):
+        return hash(self.function_call_key)
+
+    def __eq__(self, other):
+        return self.function_call_key == other.function_call_key
+
+    def __str__(self):
+        return 'PeriodicFunction({})'.format(self.function_call_key)
+
+    @cached_property
+    def function_call_key(self):
+        """Return the function's cache key."""
+        return _make_function_call_key(self.function, (), {})
+
+    def function_with_timestamp(self):
+        """Return a tuple (timestamp, result).
+
+        This is the value we actually store in the cache; the benefit is that
+        we can find the time a record was entered.
+
+        Storing them in the same record helps to avoid race conditions.
+        """
+        return (datetime.now(), self.function())
+
+    def last_update(self):
+        """Return the timestamp of the last update of this function.
+
+        If the function has never been updated, returns None."""
+        try:
+            timestamp, result = cache_lookup(self.function_call_key)
+            return timestamp
+        except KeyError:
+            return None
+
+    def seconds_since_last_update(self):
+        """Return the number of seconds since the last update.
+
+        If we've never updated, we return the number of seconds since
+        1970 so that you can still do the normal type of comparisons.
+        """
+        last_update = self.last_update() or datetime.fromtimestamp(0)
+        return (datetime.now() - last_update).total_seconds()
+
+    def result(self):
+        """Return the result of this periodic function.
+
+        In most cases, we can read it from the cache and so it is nearly
+        instant. If for some reason it isn't in the cache, we execute it (and
+        then stick it in the cache for next time).
+        """
+        timestamp, result = cache_lookup_with_fallback(
+            self.function_call_key,
+            self.function_with_timestamp,
+            ttl=self.ttl,
+        )
+        return result
+
+    def update(self):
+        """Run this periodic function and cache the result."""
+        cache_lookup_with_fallback(
+            self.function_call_key,
+            self.function_with_timestamp,
+            ttl=self.ttl,
+            force_miss=True,
+        )
+
+
+def periodic(period, ttl=None):
+    """Caching function decorator for functions which desire TTL-based caching.
+
+    Using this decorator on a function registers it as a "periodic function",
+    with the given period in seconds. The function will be run in the
+    background at the requested frequency.
+
+    When the function is called normally, a recent cached verison will thus
+    almost certainly be available for immediate use, making the website fast
+    for all users.
+
+    The optional ttl (in seconds) specifies how long cache entries should live.
+    By default, it is twice the period. If your function is called without
+    being cached, it is synchronously executed (and the result stored for next
+    time), much like the @cache decorator.
+
+    Periodic functions can have no required arguments. While they can have
+    keyword arguments, no caching is done if you call the function using them.
+
+    Uses the Django cache (which uses Redis) to achieve a shared cache across
+    worker processes.
+
+    In DEBUG mode, no caching is done.
+
+    Usage:
+
+        @periodic(60)
+        def get_blog_posts():
+            ....
+    """
+    if ttl is None:
+        ttl = period * 2
+
+    def outer(fn):
+        pf = PeriodicFunction(
+            function=fn,
+            period=period,
+            ttl=ttl,
+        )
+        periodic_functions.add(pf)
+        return pf.result
+
+    return outer

--- a/ocfweb/component/blog.py
+++ b/ocfweb/component/blog.py
@@ -46,7 +46,7 @@ class Post(namedtuple('Post', [
 def get_blog_posts():
     """Parse the beautiful OCF status blog atom feed into a list of Posts."""
     tree = etree.fromstring(
-        requests.get('http://status.ocf.berkeley.edu/feeds/posts/default', timeout=0.1).content
+        requests.get('http://status.ocf.berkeley.edu/feeds/posts/default', timeout=2).content
     )
     return [
         Post.from_element(post)

--- a/ocfweb/component/blog.py
+++ b/ocfweb/component/blog.py
@@ -4,7 +4,7 @@ import dateutil.parser
 import requests
 from lxml import etree
 
-from ocfweb.caching import cache
+from ocfweb.caching import periodic
 
 
 _namespaces = {'atom': 'http://www.w3.org/2005/Atom'}
@@ -42,7 +42,7 @@ class Post(namedtuple('Post', [
         return cls(**attrs)
 
 
-@cache(ttl=60)
+@periodic(60)
 def get_blog_posts():
     """Parse the beautiful OCF status blog atom feed into a list of Posts."""
     tree = etree.fromstring(

--- a/ocfweb/main/home.py
+++ b/ocfweb/main/home.py
@@ -5,26 +5,19 @@ from django.shortcuts import render_to_response
 from django.template import RequestContext
 from ocflib.lab.hours import Day
 from ocflib.lab.staff_hours import get_staff_hours_soonest_first
-from requests.exceptions import RequestException
 
-from ocfweb.caching import cache
+from ocfweb.caching import periodic
 from ocfweb.component.blog import get_blog_posts
 from ocfweb.component.lab_status import get_lab_status
 
 
-@cache(ttl=60)
+@periodic(60)
 def get_staff_hours():
     return get_staff_hours_soonest_first()[:2]
 
 
 def home(request):
-    try:
-        # fetching blog posts is hella flaky, we don't want to 500 if it fails
-        # TODO: do in a background job to avoid this
-        blog_posts = get_blog_posts()[:2]
-    except RequestException:
-        blog_posts = []
-
+    blog_posts = get_blog_posts()[:2]
     hours = [Day.from_date(date.today() + timedelta(days=i)) for i in range(3)]
     return render_to_response(
         'home.html',

--- a/ocfweb/settings.py
+++ b/ocfweb/settings.py
@@ -30,6 +30,7 @@ INSTALLED_APPS = (
     'ocfweb.main',
     'ocfweb.middleware',
     'ocfweb.stats',
+    'ocfweb.test',
 )
 
 MIDDLEWARE_CLASSES = (

--- a/ocfweb/test/periodic.py
+++ b/ocfweb/test/periodic.py
@@ -1,0 +1,17 @@
+from operator import attrgetter
+
+from django.shortcuts import render_to_response
+from django.template import RequestContext
+
+from ocfweb.caching import periodic_functions
+
+
+def test_list_periodic_functions(request):
+    return render_to_response(
+        'periodic.html',
+        {
+            'title': 'Periodic Functions List',
+            'periodic_functions': sorted(periodic_functions, key=attrgetter('function_call_key')),
+        },
+        context_instance=RequestContext(request),
+    )

--- a/ocfweb/test/templates/periodic.html
+++ b/ocfweb/test/templates/periodic.html
@@ -1,0 +1,26 @@
+{% extends 'base.html' %}
+
+{% block content %}
+    <div class="ocf-content-block">
+        <table class="table">
+            <tr>
+                <th>Function</th>
+                <th>Period (seconds)</th>
+                <th>TTL (seconds)</th>
+                <th>Age (seconds)</th>
+            </tr>
+
+
+            {% for periodic_function in periodic_functions %}
+                <tr>
+                    <td>{{periodic_function}}</td>
+                    <td>{{periodic_function.period}}</td>
+                    <td>{{periodic_function.ttl}}</td>
+                    <td>{{periodic_function.seconds_since_last_update}}</td>
+                </tr>
+            {% endfor %}
+        </table>
+
+        <p>If everything is working properly, we expect age &lt; period &lt; ttl.</p>
+    </div>
+{% endblock %}

--- a/ocfweb/urls.py
+++ b/ocfweb/urls.py
@@ -15,6 +15,7 @@ from ocfweb.main.move_to_mlk import move_to_mlk
 from ocfweb.main.staff_hours import staff_hours
 from ocfweb.stats.daily_graph import daily_graph_image
 from ocfweb.stats.summary import summary
+from ocfweb.test.periodic import test_list_periodic_functions
 from ocfweb.test.session import test_session
 
 
@@ -22,6 +23,7 @@ urlpatterns = [
     # test pages
     url('^_status$', lambda _: HttpResponse('ok'), name='status'),
     url('^test/session$', test_session, name='test_session'),
+    url('^test/periodic$', test_list_periodic_functions, name='test_list_periodic_functions'),
 
     url('^$', home, name='home'),
     url('^favicon.ico$', favicon, name='favicon'),

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         'python-dateutil',
     ],
     sass_manifests={
-        'ocfweb': ['static/scss'],
+        'ocfweb': ('static/scss',),  # XXX: must be tuple
     },
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,11 @@ setup(
         'python-dateutil',
     ],
     sass_manifests={
-        'ocfweb': ('static/scss',),
+        'ocfweb': ['static/scss'],
+    },
+    entry_points={
+        'console_scripts': [
+            'ocfweb-run-periodic-functions = ocfweb.bin.run_periodic_functions:main',
+        ],
     },
 )


### PR DESCRIPTION
Right now on ocfweb we have a lot of really slow calls:

* loading blog posts
* loading staff hours (mostly LDAP)
* loading lab_status (HTTP to death)
* loading stats

Some of these are behind a caching decorator, where the result is saved for some seconds (but one poor user still has to wait a long time to view the page, and because of low traffic on some of the pages, lots of users end up being poor users).

This introduces periodic functions. The docstring explains pretty well:

```python
def periodic(period, ttl=None):
    """Caching function decorator for functions which desire TTL-based caching.

    Using this decorator on a function registers it as a "periodic function",
    with the given period in seconds. The function will be run in the
    background at the requested frequency.

    When the function is called normally, a recent cached verison will thus
    almost certainly be available for immediate use, making the website fast
    for all users.

    The optional ttl (in seconds) specifies how long cache entries should live.
    By default, it is twice the period. If your function is called without
    being cached, it is synchronously executed (and the result stored for next
    time), much like the @cache decorator.

    Periodic functions can have no required arguments. While they can have
    keyword arguments, no caching is done if you call the function using them.

    Uses the Django cache (which uses Redis) to achieve a shared cache across
    worker processes.

    In DEBUG mode, no caching is done.

    Usage:

        @periodic(60)
        def get_blog_posts():
```

This will role out `periodic` without adding a cronjob yet to trigger the functions. This *does* add a script to trigger them, though, and we can use it to test in prod before adding the cronjob.

Without a cronjob, the periodic decorator acts just like the cache decorator, so the site will still be equally fast (or equally slow, depending on your mood).

I want to push this now, observe it in prod, and then push a cronjob if everything goes smoothly.

This also adds a test page where you can see some statistics:

![](http://i.fluffy.cc/CHk84H0TdzQkp0zWVL5XNlGzJxx8nrRf.png)

This is purely informational and kind of useful. We can leave it on in prod since it's read-only and nothing sensitive is in it.

The decorator is very easy to use; you can throw it on any function you'd like (as long as it has no arguments), and it will automatically be added to the list of background jobs. You can call that function just like you normally would, and it will usually be instant.

This should make it easy for us to keep ocfweb fast without the same kind of cronjob hacks we had in e.g. labstats.