### PR TITLE
Rename csrftoken cookie and make it HTTP-only

### DIFF
--- a/ocfweb/settings.py
+++ b/ocfweb/settings.py
@@ -82,7 +82,13 @@ DATABASES = {}
 SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
 
 # XXX: DO NOT CHANGE
-# Ensure cookies can't be read by JavaScript.
+# Ensure cookies can't be read by JavaScript or users.
+# Our proxy filters cookies starting with "OCFWEB_" when going to user sites,
+# so it's important our cookies match this pattern.
+CSRF_COOKIE_HTTPONLY = True
+CSRF_COOKIE_SECURE = False
+CSRF_COOKIE_PATH = '/'
+CSRF_COOKIE_NAME = 'OCFWEB_CSRF_TOKEN'
 SESSION_COOKIE_HTTPONLY = True
 SESSION_COOKIE_SECURE = False
 SESSION_COOKIE_PATH = '/'
@@ -156,6 +162,8 @@ if getuser() == 'ocfweb':
         }
     }
 
+    CSRF_COOKIE_SECURE = True
+    CSRF_COOKIE_DOMAIN = 'www.ocf.berkeley.edu'
     SESSION_COOKIE_SECURE = True
     SESSION_COOKIE_DOMAIN = 'www.ocf.berkeley.edu'
 else:


### PR DESCRIPTION
We do this for the session cookie, we should do it for the CSRF token too.

https://docs.djangoproject.com/en/1.9/ref/settings/#std:setting-CSRF_COOKIE_NAME