### PR TITLE
Fix spurious CacheKeyWarnings. Close #135

### DIFF
--- a/ocfweb/caching.py
+++ b/ocfweb/caching.py
@@ -110,13 +110,15 @@ def _make_key(key):
     The returned key prepends a version tag so that we don't share the cache
     across ocfweb versions. This prevents strange behavior (e.g. if you change
     the return type of a function which was cached on the previous version).
+    The cache keys have spaces removed and are limited to under 250 characters
+    to preserve portability with memcached.
 
     :param key: some iterable key (e.g. a tuple or list)
     """
-    return tuple(chain(
+    return str(tuple(chain(
         [ocfweb_version()],
         key,
-    ))
+    ))).replace(' ', '')[:240]
 
 
 def _make_function_call_key(fn, args, kwargs):


### PR DESCRIPTION
This works to remove the `CacheKeyWarning` issue described in #135. However, it might not work if the key is the same for the first 240 characters, but differs later on in the key. If that's the case, then the cache will collide and return an incorrect result when fetched from the cache. I also tried limiting to 250 characters instead of 240, and it still said the cache key was over 250 characters, so I believe there are some extra characters being counted somewhere. If we wanted to use longer keys, or think that this might become a problem in the future, then we should just ignore the errors, as suggested as an option in #135.