### PR TITLE
Reload docs in development

### DIFF
--- a/ocfweb/docs/doc.py
+++ b/ocfweb/docs/doc.py
@@ -3,7 +3,12 @@ from collections import namedtuple
 from cached_property import cached_property
 
 
-class Document(namedtuple('Document', ['name', 'title', 'render'])):
+class Document(namedtuple('Document', ['name', 'title', 'render', 'path'])):
+
+    # namedtuple with optional keyword arguments,
+    # credit to http://stackoverflow.com/a/16721002
+    def __new__(cls, name, title, render, path=None):
+        return super(Document, cls).__new__(cls, name, title, render, path)
 
     @cached_property
     def category(self):

--- a/ocfweb/docs/doc.py
+++ b/ocfweb/docs/doc.py
@@ -3,12 +3,7 @@ from collections import namedtuple
 from cached_property import cached_property
 
 
-class Document(namedtuple('Document', ['name', 'title', 'render', 'path'])):
-
-    # namedtuple with optional keyword arguments,
-    # credit to http://stackoverflow.com/a/16721002
-    def __new__(cls, name, title, render, path=None):
-        return super(Document, cls).__new__(cls, name, title, render, path)
+class Document(namedtuple('Document', ['name', 'title', 'render'])):
 
     @cached_property
     def category(self):

--- a/ocfweb/docs/markdown_based.py
+++ b/ocfweb/docs/markdown_based.py
@@ -1,6 +1,6 @@
 """Documents backed by Markdown.
 
-This is the most common type of doc. It reads a Markdown fil and renders it in
+This is the most common type of doc. It reads a Markdown file and renders it in
 a standard template.
 
 Markdown documents can specify the meta attributes:
@@ -16,6 +16,7 @@ import os
 from functools import partial
 from pathlib import Path
 
+from django.conf import settings
 from django.shortcuts import render
 
 from ocfweb.component.markdown import markdown_and_toc
@@ -27,12 +28,19 @@ DOCS_DIR = Path(__file__).parent.joinpath('docs')
 
 
 def render_markdown_doc(meta, text, doc, request):
+
+    # Reload markdown docs if in development
+    if settings.DEBUG:
+        with doc.path.open() as f:
+            text, meta = text_and_meta(f)
+
     html, toc = markdown_and_toc(text)
+
     return render(
         request,
         meta.get('template', 'doc.html'),
         {
-            'title': doc.title,
+            'title': meta['title'],
             'doc': doc,
             'html': html,
             'toc': toc,
@@ -56,5 +64,6 @@ def get_markdown_docs():
         yield Document(
             name='/' + name,
             title=meta['title'],
-            render=partial(render_markdown_doc, meta, text)
+            render=partial(render_markdown_doc, meta, text),
+            path=path,
         )

--- a/ocfweb/docs/markdown_based.py
+++ b/ocfweb/docs/markdown_based.py
@@ -27,11 +27,11 @@ from ocfweb.docs.doc import Document
 DOCS_DIR = Path(__file__).parent.joinpath('docs')
 
 
-def render_markdown_doc(meta, text, doc, request):
+def render_markdown_doc(path, meta, text, doc, request):
 
     # Reload markdown docs if in development
     if settings.DEBUG:
-        with doc.path.open() as f:
+        with path.open() as f:
             text, meta = text_and_meta(f)
 
     html, toc = markdown_and_toc(text)
@@ -64,6 +64,5 @@ def get_markdown_docs():
         yield Document(
             name='/' + name,
             title=meta['title'],
-            render=partial(render_markdown_doc, meta, text),
-            path=path,
+            render=partial(render_markdown_doc, path, meta, text),
         )


### PR DESCRIPTION
Addresses #136.

Unfortunately, reloading page _titles_ in development is not as easy, since they are stored in the documents themselves and require reading all of the markdown files every load to generate the proper trees. The current page title will update with these changes, but the same page's title shown on other pages will not change. Not sure if there is a better way to change that other than reading in all of the markdown files, but changing page titles should happen far less than changing their contents. New markdown files are also not recognized, so maybe reading in all the files would work well to fix these additional issues?