### PR TITLE
Show minutes in lab hours when relevant

### DIFF
--- a/ocfweb/templatetags/lab_hours.py
+++ b/ocfweb/templatetags/lab_hours.py
@@ -14,8 +14,10 @@ def lab_hours_holiday(hours):
 def lab_hours_time(hours):
     if hours:
         return ',\xa0\xa0'.join(  # two non-breaking spaces
-            '{:%-I%P}–{:%-I%P}'.format(hours.open, hours.close)
-            for hours in hours
+            '{:%-I:%M%P}–{:%-I:%M%P}'.format(hour.open, hour.close)
+            if hour.open.minute != 0 or hour.close.minute != 0
+            else '{:%-I%P}–{:%-I%P}'.format(hour.open, hour.close)
+            for hour in hours
         )
     else:
         return 'Closed All Day'


### PR DESCRIPTION
I think we didn't notice they were missing because we're used to the way they're presented now. It seemed like a good idea to hide the minute when we open/close unless either is not on the hour, i.e. 9:10am-6:00pm on Tuesday but 9am-9pm on regular days.