### PR TITLE
docs: create a live command reference page

### DIFF
--- a/ocfweb/docs/templates/commands.html
+++ b/ocfweb/docs/templates/commands.html
@@ -1,0 +1,93 @@
+{% extends 'base.html' %}
+
+{% block content %}
+  <div class="ocf-content-block">
+    <h2>Shell interface</h2>
+    <div class="shell-wrapper">
+      <iframe src="https://ssh.ocf.berkeley.edu" class="shell-frame">
+        <p>Sorry! Your browser can't display this window.</p>
+      </iframe>
+    </div>
+    <p>
+      Welcome to the live command reference! Here you can securely access our
+      login server via <a href="{% url 'doc' 'services/shell' %}">SSH</a> and
+      run commands to manage your account, edit a website, or work on our
+      server. Below is a list of account management commands with a brief
+      description of what they do and how to use them. Simply type in a command
+      and hit enter to run it. To log out, run the command <code>exit</code>.
+    </p>
+    <h2>OCF commands</h2>
+      <table class="table table-striped table-hover">
+        <caption>
+          <strong>Key:</strong>
+          <code>ARGUMENT</code>
+          <code>[optional]</code>
+        </caption>
+        <tr>
+          <th>Command</th>
+          <th>Description</th>
+        </tr>
+        {% for command in ocf_commands %}
+          <tr>
+            <td>
+              <code>
+                <strong>
+                  {% if command.doc %}
+                    <a href="{% url 'doc' command.doc %}#{{command.doc_anchor}}">
+                      {{command.name}}
+                    </a>
+                  {% else %}
+                    {{command.name}}
+                  {% endif %}
+                </strong>
+                {% if command.args %}
+                  {{command.args}}
+                {% endif %}
+              </code>
+            </td>
+            <td>
+              {{command.desc | safe}}
+            </td>
+          </tr>
+        {% endfor %}
+      </table>
+    <h2>File commands</h2>
+      <p>
+        For convenience, here is a very basic listing of commands to manage
+        files. For a more complete listing, see for example <a
+        href="https://en.wikipedia.org/wiki/List_of_Unix_commands">
+        Wikipedia</a>. For more information on a specific command, run
+        <code>man COMMAND</code>.
+      </p>
+      <table class="table table-striped table-hover">
+        <caption>
+          <strong>Key:</strong>
+          <code>ARGUMENT</code>
+          <code>[optional]</code>
+        </caption>
+        <tr>
+          <th>Command</th>
+          <th>Description</th>
+        </tr>
+        {% for command in file_commands %}
+          <tr>
+            <td>
+              <code>
+                <strong>
+                  {% if command.doc %}
+                    <a href="{% url 'doc' command.doc %}">{{command.name}}</a>
+                  {% else %}
+                    {{command.name}}
+                  {% endif %}
+                </strong>
+                {{command.args}}
+              </code>
+            </td>
+            <td>
+              {{command.desc | safe}}
+            </td>
+          </tr>
+        {% endfor %}
+      </table>
+  </div>
+{% endblock %}

--- a/ocfweb/docs/urls.py
+++ b/ocfweb/docs/urls.py
@@ -6,6 +6,7 @@ from django.http import Http404
 
 from ocfweb.docs.doc import Document
 from ocfweb.docs.markdown_based import get_markdown_docs
+from ocfweb.docs.views.commands import commands
 from ocfweb.docs.views.hosting_badges import hosting_badges
 from ocfweb.docs.views.index import docs_index
 from ocfweb.docs.views.lab import lab
@@ -21,6 +22,7 @@ DOCS = {
             Document(name='/staff/backend/servers', title='Servers', render=servers),
             Document(name='/services/vhost/badges', title='Hosting badges', render=hosting_badges),
             Document(name='/services/lab', title='Computer lab', render=lab),
+            Document(name='/services/shell/commands', title='Command reference', render=commands),
         ],
         get_markdown_docs(),
     )

--- a/ocfweb/docs/views/commands.py
+++ b/ocfweb/docs/views/commands.py
@@ -1,0 +1,88 @@
+from collections import namedtuple
+
+from django.shortcuts import render
+
+
+Command = namedtuple('Command', ['name', 'args', 'desc', 'doc', 'doc_anchor'])
+# Default last two fields to None
+Command.__new__.__defaults__ = (None, None)
+
+
+OCF_COMMANDS = [
+    Command(
+        'how', 'SCRIPT',
+        desc='Shows the source code for a script',
+    ),
+    Command(
+        'makehttp', None,
+        desc='Puts a shortcut to your web directory in your home folder',
+        doc='services/web', doc_anchor='h3_via-ssh',
+    ),
+    Command(
+        'makemysql', None,
+        desc='Generates a new random password for your database, creating the '
+             'database if it does no exist',
+        doc='services/mysql', doc_anchor='h3_ssh-terminal',
+    ),
+    Command(
+        'paper', None,
+        desc='Shows how many pages you can currently print',
+    ),
+    Command(
+        'update-email', None,
+        desc='Prompts you to set a contact email address for your OCF account',
+    ),
+]
+
+FILE_COMMANDS = [
+    Command(
+        'cd', 'DIRECTORY',
+        desc='Changes the current directory to a new one',
+    ),
+    Command(
+        'cp', '[-r] SOURCE DEST',
+        desc='Copies a file. The <code>-r</code> option allows for copying '
+             'directories.',
+    ),
+    Command(
+        'less', 'FILE',
+        desc='Lets you view the contents of a text file',
+    ),
+    Command(
+        'ls', '[FILE]',
+        desc='Lists information about files and directories',
+    ),
+    Command(
+        'mkdir', 'DIRECTORY',
+        desc='Creates a new directory'
+    ),
+    Command(
+        'nano', 'FILE',
+        desc='Lets you edit a text file with a basic interface',
+    ),
+    Command(
+        'mv', 'SOURCE DEST',
+        desc='Moves or renames a file or folder',
+    ),
+    Command(
+        'rm', '[-r] FILE',
+        desc='Deletes a file. The <code>-r</code> option allows for deleting '
+             'non-empty directories.',
+    ),
+    Command(
+        'rmdir', 'DIRECTORY',
+        desc='Deletes an empty directory. Safer than <code>rm -r</code>.',
+    ),
+]
+
+
+def commands(doc, request):
+    return render(
+        request,
+        'commands.html',
+        {
+            'title': doc.title,
+            'ocf_commands': OCF_COMMANDS,
+            'file_commands': FILE_COMMANDS,
+        },
+    )

--- a/ocfweb/static/scss/pages/docs.scss
+++ b/ocfweb/static/scss/pages/docs.scss
@@ -1,4 +1,5 @@
 @import '../ocf';
+@import 'docs/commands';
 @import 'docs/servers';
 
 .page-doc .ocf-content-block {

--- a/ocfweb/static/scss/pages/docs/commands.scss
+++ b/ocfweb/static/scss/pages/docs/commands.scss
@@ -1,0 +1,20 @@
+@import '../../ocf';
+
+.page-doc-services-shell-commands {
+    .shell-wrapper {
+        padding: 16px;
+
+        iframe {
+            width: 100%;
+            height: 200px;
+
+            @media (min-width: $screen-sm-min) {
+                height: 300px;
+            }
+
+            @media (min-width: $screen-md-min) {
+                height: 400px;
+            }
+        }
+    }
+}


### PR DESCRIPTION
@daradib suggested this several weeks ago. It seems like a modestly helpful improvement over logging directly into ssh.o.b.e from a browser.

![screenshot - 04042016 - 03 48 54 pm](https://cloud.githubusercontent.com/assets/6722367/14266394/c410a112-fa7c-11e5-9614-9ec9f205d775.png)

I duplicated the OCF command table to include some basic file manipulation help. I don't know if it's worth keeping, but, if we do so, the table could be made into a partial template and the reference section expanded.

Also, I couldn't get the iframe to properly scale while keeping aspect ratio, so this is my attempt at responsive.