### PR TITLE
Fix broken requirements pinning in prod

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -16,7 +16,7 @@ unexport LDFLAGS
 override_dh_virtualenv:
 	# XXX: pip 8.1.0 breaks our build
 	# https://github.com/ocf/ocfweb/issues/159
-	dh_virtualenv --python=/usr/bin/python3 --extra-pip-arg='--upgrade' --preinstall=pip==8.0.3 --preinstall=wheel
+	dh_virtualenv --python=/usr/bin/python3 --preinstall=pip==8.0.3 --preinstall=wheel==0.29.0
 
 	# build sass, output static files
 	$(PYTHON) setup.py build_sass


### PR DESCRIPTION
pyparsing 2.1.2 was just released today: https://pypi.python.org/pypi/pyparsing/2.1.2

we pin pyparsing==2.1.1 so there's no reason 2.1.2 should have been installed in our built package, but it was

something broken in pyparsing 2.1.1 gave us weird tracebacks, only in prod (dev was fine, since using 2.1.1): https://gist.github.com/anonymous/9d1cd2db89f20495267c141bc0dbccd7

turns out our use of --upgrade was incorrect in debian/rules:
https://github.com/ocf/ocfweb/blob/7dd738931f1d942d6444fe3c1c18db06a127fb87/debian/rules#L19

the --upgrade meant that when dh-virtualenv did "pip install [ocfweb]" it would actually upgrade dependencies, even if older (pinned) versions were already installed

now that we pin a specific version of pip (due to https://github.com/ocf/ocfweb/pull/160) we can drop --upgrade entirely