### PR TITLE
Add catch-all support for vhost mail

### DIFF
--- a/ocfweb/account/templates/account/partials/vhost_mail/modals/add-address.html
+++ b/ocfweb/account/templates/account/partials/vhost_mail/modals/add-address.html
@@ -13,15 +13,23 @@
     <div class="form-group">
         <label for="add-modal-addr">
             Incoming address<br />
-            <span class="desc">
-                This is the receiving address. Only include the part before
-                the "@" sign.
-            </span>
+            <div class="hide-wildcard">
+                <span class="desc">
+                    This is the receiving address. Only include the part before
+                    the "@" sign.
+                </span>
+                <div class="alert alert-danger js-warn-addr" style="display: none;">
+                    Don't include an "@" sign or the domain name!
+                </div>
+                <input type="text" class="form-control" name="name" placeholder="john" id="add-modal-addr" />
+            </div>
+            <div class="show-wildcard">
+                <span class="desc">
+                    Catch-all address. All emails to <tt>{anything}@<span class="js-domain"></span></tt>
+                    which don't match any other address will go here.
+                </span>
+            </div>
         </label>
-        <div class="alert alert-danger js-warn-addr" style="display: none;">
-            Don't include an "@" sign or the domain name!
-        </div>
-        <input type="text" class="form-control" name="name" placeholder="john" id="add-modal-addr" />
     </div>
     <div class="form-group">
         <label>
@@ -40,7 +48,7 @@
             </button>
         </p>
     </div>
-    <div class="form-group">
+    <div class="form-group hide-wildcard">
         <label for="add-modal-password">
             Password<br />
             <span class="desc">

--- a/ocfweb/account/templates/account/vhost_mail/index.html
+++ b/ocfweb/account/templates/account/vhost_mail/index.html
@@ -20,7 +20,7 @@
             {% for vhost in vhosts %}
                 <hr />
                 <h3>{{vhost.domain}}</h3>
-                {% with vhost|forwarding_addresses:c as forwarding_addresses %}
+                {% with vhost.addresses as forwarding_addresses %}
                     <table class="table table-striped">
                         <tr>
                             <th>Email address</th>
@@ -30,15 +30,42 @@
                             <th>&nbsp;</th>
                         </tr>
 
+                        {% if not vhost.has_wildcard %}
+                            <tr class="no-catchall">
+                                <td colspan="5">
+                                    <strong>You don't have a catch-all address set.</strong>
+                                    <a
+                                        role="button"
+                                        class="js-add-catchall"
+                                        data-toggle="popover"
+                                        data-trigger="focus"
+                                        data-placement="bottom"
+                                        data-domain="{{vhost.domain}}"
+                                    >More details.</a>
+                                </td>
+                            <tr>
+                        {% endif %}
+
                         {% if forwarding_addresses %}
                             {% for addr in forwarding_addresses %}
                                 <tr>
                                     <td>
-                                        <p>
-                                            <!-- pardon long line, must avoid spacing -->
-                                            {{addr.address|address_to_parts|getitem:0}}<span class="subtle">@{{addr.address|address_to_parts|getitem:1}}</span>
-                                        </p>
-                                        <small><a role="button">Edit</a></small>
+                                        {% if not addr.is_wildcard %}
+                                            <p>
+                                                <!-- pardon long line, must avoid spacing -->
+                                                {{addr.address|address_to_parts|getitem:0}}<span class="subtle">@{{addr.address|address_to_parts|getitem:1}}</span>
+                                            </p>
+                                            <small><a role="button">Edit</a></small>
+                                        {% else %}
+                                            Catch-all address<br />
+                                            <a
+                                                role="button"
+                                                class="small js-catchall-whats-this"
+                                                data-toggle="popover"
+                                                data-trigger="focus"
+                                                data-placement="bottom"
+                                            >What's this?</a>
+                                        {% endif %}
                                     </td>
                                     <td>
                                         <ul class="list-unstyled">
@@ -51,13 +78,17 @@
                                         </small>
                                     </td>
                                     <td>
-                                        <small><a role="button" data-addr="{{addr.address}}" class="js-change-password">
-                                            {% if addr.crypt_password %}
-                                                Change
-                                            {% else %}
-                                                Set
-                                            {% endif %}
-                                        </a></small>
+                                        {% if not addr.is_wildcard %}
+                                            <small><a role="button" data-addr="{{addr.address}}" class="js-change-password">
+                                                {% if addr.crypt_password %}
+                                                    Change
+                                                {% else %}
+                                                    Set
+                                                {% endif %}
+                                            </a></small>
+                                        {% else %}
+                                            n/a
+                                        {% endif %}
                                     </td>
                                     <td title="{{addr.last_updated}}">{{addr.last_updated|naturaltime}}</td>
                                     <td>

--- a/ocfweb/account/templatetags/vhost_mail.py
+++ b/ocfweb/account/templatetags/vhost_mail.py
@@ -1,16 +1,6 @@
-import operator
-
 from django import template
 
 register = template.Library()
-
-
-@register.filter
-def forwarding_addresses(vhost, c):
-    return sorted(
-        vhost.get_forwarding_addresses(c),
-        key=operator.attrgetter('address'),
-    )
 
 
 @register.filter

--- a/ocfweb/static/scss/pages/account/vhost_mail.scss
+++ b/ocfweb/static/scss/pages/account/vhost_mail.scss
@@ -17,4 +17,28 @@
             padding-right: 0;
         }
     }
+
+    .no-catchall {
+        background-color: #fdfdde;
+        font-size: 14px;
+
+        td {
+            padding: 15px;
+        }
+    }
+
+
+    .js-wildcard {
+        .hide-wildcard {
+            display: none;
+        }
+
+        .show-wildcard {
+            display: block;
+        }
+    }
+
+    .show-wildcard {
+        display: none;
+    }
 }


### PR DESCRIPTION
This is what it looks like if you haven't set a catch-all email:

![](https://i.fluffy.cc/NcHL5FqKddTTjX0Blc11WpGhWmRfsbVV.png)

Here's the modal where you add one (same as the normal add modal, but with the incoming address and password fields omitted):

![](https://i.fluffy.cc/0Sw4F7Gdpff9Z5ggzxV14pHdP3BJ0Bwn.png)

Here's what it looks like when you have a catch-all email:

![](https://i.fluffy.cc/KDH93w3ZwbM3DntvlwV1wKFG7vCW02zS.png)

(The popovers obviously start closed, I just opened them for the sake of the screenshots.)