### PR TITLE
Remove "free" before printing

### DIFF
--- a/ocfweb/about/templates/about/staff.html
+++ b/ocfweb/about/templates/about/staff.html
@@ -66,7 +66,7 @@
                     </div>
                     <div class="col-sm-4">
                         <p><img src="{% static 'img/about/lab.png' %}" alt="computer lab" /></p>
-                        <h3>Computer Lab &amp; Free Printing</h3>
+                        <h3>Computer Lab &amp; Printing</h3>
                         <p>Our computer lab has free printing, scanners, mechanical keyboards, and blazing fast computers running Linux!</p>
                     </div>
                     <div style="clear:both;"></div>

--- a/ocfweb/docs/docs/about.md
+++ b/ocfweb/docs/docs/about.md
@@ -13,7 +13,7 @@ place for those interested in computing to fully explore that interest.
 ## What do we do?
 
 The Open Computing Facility provides free computing services to student,
-faculty, and staff, ranging from free printing to expiration-free web
+faculty, and staff, ranging from printing to expiration-free web
 space to Unix shell accounts to email. Furthermore, the OCF operates a
 highly frequented long-hours computing lab with a generally high
 volunteer-staff-to-user ratio for accessible in-person support, as well


### PR DESCRIPTION
I think this is the third time I changed the home page to
just say printing like our other free as in beer services.
This time we have version control. Long live version control.