### PR TITLE
Add a Dockerfile and some related config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+debian
+venv
+.tox
+.git
+*.swp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+FROM docker.ocf.berkeley.edu/theocf/debian:jessie
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        build-essential \
+        libcrack2-dev \
+        libffi-dev \
+        libfreetype6-dev \
+        libpng12-dev \
+        libssl-dev \
+        libxft-dev \
+        libxml2-dev \
+        locales \
+        python3 \
+        python3-dev \
+        python3-pip \
+        redis-tools \
+        runit \
+        spiped \
+        virtualenv \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN install -d --owner=nobody /opt/ocfweb /opt/ocfweb/venv /etc/ocfweb
+
+COPY requirements.txt /opt/ocfweb/
+# TODO: We can't use libsass==0.11.1 in the Debian packaging yet, but we can here.
+# We go to the pain of sed-ing it out because 0.11.1 has a manylinux wheel.
+RUN sed -i 's/^libsass==.*/libsass==0.11.1/' /opt/ocfweb/requirements.txt
+RUN virtualenv -ppython3 /opt/ocfweb/venv \
+    && /opt/ocfweb/venv/bin/pip install pip==8.1.2 \
+    && /opt/ocfweb/venv/bin/pip install \
+        -r /opt/ocfweb/requirements.txt
+
+COPY ocfweb /opt/ocfweb/ocfweb/
+COPY services /opt/ocfweb/services/
+COPY conf /etc/ocfweb/
+ENV MATPLOTLIBRC /etc/ocfweb
+
+# Marathon will set this to 0, but we set it to 1 in case staff run this
+# locally to prevent ocflib report emails.
+ENV OCFWEB_TESTING 1
+
+# Some files need to be writable.
+RUN chown -R nobody:nogroup /opt/ocfweb/services
+
+WORKDIR /opt/ocfweb
+USER nobody
+CMD ["runsvdir", "/opt/ocfweb/services"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,56 @@
+stage name: 'clean-workspace'
+node('slave') {
+    step([$class: 'WsCleanup'])
+}
+
+// check out code
+stage name: 'check-out-code'
+node('slave') {
+    dir('src') {
+        checkout scm
+    }
+    stash 'src'
+}
+
+
+// run tests
+stage name: 'test'
+
+node('slave') {
+    unstash 'src'
+    dir('src') {
+        sh 'make test'
+    }
+}
+
+
+// deploy to prod
+if (env.BRANCH_NAME == 'master') {
+    def version = new Date().format("yyyy-MM-dd-'T'HH-mm-ss")
+    withEnv(["DOCKER_TAG=docker-push.ocf.berkeley.edu/ocfweb:${version}"]) {
+        stage name: 'build-prod-image'
+        node('slave') {
+            unstash 'src'
+            dir('src') {
+                sh 'make cook-image'
+            }
+        }
+
+        stage name: 'push-to-registry'
+        node('deploy') {
+            unstash 'src'
+            dir('src') {
+                sh 'make push-image'
+            }
+        }
+    }
+
+    stage name: 'deploy-to-prod'
+    build job: 'marathon-deploy-app', parameters: [
+        [$class: 'StringParameterValue', name: 'app', value: 'ocfweb'],
+        [$class: 'StringParameterValue', name: 'version', value: version],
+    ]
+}
+
+
+// vim: ft=groovy

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,21 @@ BIN := venv/bin
 PYTHON := $(BIN)/python
 SHELL := /bin/bash
 RANDOM_PORT := $(shell expr $$(( 8000 + (`id -u` % 1000) )))
+DOCKER_TAG ?= ocfweb-dev-$(USER)
 
 .PHONY: test
 test: venv
 	$(BIN)/coverage run -m py.test -v tests/
 	$(BIN)/coverage report
 	$(BIN)/pre-commit run --all-files
+
+.PHONY: cook-image
+cook-image:
+	docker build -t $(DOCKER_TAG) .
+
+.PHONY: push-image
+push-image: cook-image
+	docker push $(DOCKER_TAG)
 
 # first set COVERALLS_REPO_TOKEN=<repo token> environment variable
 .PHONY: coveralls

--- a/conf/ocfweb.conf
+++ b/conf/ocfweb.conf
@@ -1,0 +1,17 @@
+[django]
+secret = not_a_secret
+debug = false
+redis_uri = redis://127.0.0.1:6378/0
+
+# static assets
+static_url = /static/
+static_root =
+
+[celery]
+broker = redis://127.0.0.1:6378
+backend = redis://127.0.0.1:6378
+
+[ocfmail]
+user = ocfmail
+password = password
+db = ocfmail

--- a/debian/postinst
+++ b/debian/postinst
@@ -5,6 +5,7 @@ if [ ! -f /etc/ocfweb/ocfweb.conf ]; then
 [django]
 secret = not_a_secret
 debug = false
+redis_uri = redis://localhost:6379/0
 
 # static assets
 static_url = https://static.ocf.berkeley.edu/

--- a/ocfweb/settings.py
+++ b/ocfweb/settings.py
@@ -1,14 +1,13 @@
 import configparser
 import os
 import warnings
-from getpass import getuser
 
 from django.core.cache import CacheKeyWarning
 from django.template.base import TemplateSyntaxError
 
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-TESTING = False
+TESTING = os.environ.get('OCFWEB_TESTING') == '1'
 
 ALLOWED_HOSTS = [
     'www.ocf.berkeley.edu',
@@ -152,11 +151,11 @@ OCFMAIL_USER = conf.get('ocfmail', 'user')
 OCFMAIL_PASSWORD = conf.get('ocfmail', 'password')
 OCFMAIL_DB = conf.get('ocfmail', 'db')
 
-if getuser() == 'ocfweb':
+if not DEBUG:
     # Prod-only settings.
     CACHES['default'] = {
         'BACKEND': 'django_redis.cache.RedisCache',
-        'LOCATION': 'redis://localhost:6379/0',
+        'LOCATION': conf.get('django', 'redis_uri'),
         'OPTIONS': {
             'CLIENT_CLASS': 'django_redis.client.DefaultClient',
         }

--- a/services/ocfweb/run
+++ b/services/ocfweb/run
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euxo pipefail
+cd /opt/ocfweb
+exec /opt/ocfweb/venv/bin/gunicorn \
+    -b 0.0.0.0:8000 \
+    -w 4 \
+    ocfweb.wsgi

--- a/services/redis-tunnel/run
+++ b/services/redis-tunnel/run
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euxo pipefail
+
+if [ "$OCFWEB_TESTING" == "1" ]; then
+    echo 'Warning! This will probably fail in dev!'
+fi
+
+exec /usr/bin/spiped \
+    -e -D -g -F -k /etc/ocfweb/create-redis.key \
+    -p /dev/null \
+    -s 127.0.0.1:6378 \
+    -t create:6379


### PR DESCRIPTION
This isn't fully done right now. I think this is enough to work in prod
(where we have the secrets we need -- we'll find out), but definitely
not in dev yet.

There are also some other things that would eventually need to do before
we can replace coma with this, at least:

* The background worker doesn't run in this new setup yet
* Static files are still served from static.ocf.b.e which is coma