### PR TITLE
Only run test-cook-image for branches (not master)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,12 +18,6 @@ node('slave') {
         }
     }
 
-    stage('test-cook-image') {
-        dir('src') {
-            sh 'make cook-image'
-        }
-    }
-
     stash 'src'
 }
 
@@ -71,6 +65,18 @@ if (env.BRANCH_NAME == 'master') {
                     [$class: 'StringParameterValue', name: 'app', value: 'ocfweb/static'],
                     [$class: 'StringParameterValue', name: 'version', value: version],
                 ]
+            }
+        }
+    }
+} else {
+    // TODO: figure out how to do this in parallel with the previous step
+    node('slave') {
+        step([$class: 'WsCleanup'])
+        unstash 'src'
+
+        stage('test-cook-image') {
+            dir('src') {
+                sh 'make cook-image'
             }
         }
     }


### PR DESCRIPTION
There's no point running the `test-cook-image` stage on master, because we're about to do the actual `cook-image` for prod, which would fail anyway.