### PR TITLE
settings: add local host to ALLOWED_HOSTS in debug mode

### DIFF
--- a/ocfweb/settings.py
+++ b/ocfweb/settings.py
@@ -1,5 +1,6 @@
 import configparser
 import os
+import socket
 import warnings
 
 from django.core.cache import CacheKeyWarning
@@ -176,3 +177,4 @@ else:
     }
     CSRF_COOKIE_SECURE = False
     SESSION_COOKIE_SECURE = False
+    ALLOWED_HOSTS.append(socket.getfqdn())


### PR DESCRIPTION
Django 1.10.3 introduced a [change in the behavior of ALLOWED_HOSTS][1]
that breaks our debug mode. This change allows `make dev` to continue
launching a usable website, by listing the local host as an allowed host
in debug mode.

[1]: https://docs.djangoproject.com/en/1.10/releases/1.10.3/#dns-rebinding-vulnerability-when-debug-true