### PR TITLE
Add link to staff hours from docs

### DIFF
--- a/ocfweb/docs/docs/staff.md
+++ b/ocfweb/docs/docs/staff.md
@@ -3,7 +3,8 @@
 
 Find out what we're all about, and [[come join us|about-staff]]!
 
-Feel free to attend our meetings or [[contact us|doc contact]] by email.
+Feel free to attend our meetings, visit us during [[staff hours|staff-hours]],
+or [[contact us|doc contact]] by email.
 
 ### Documentation
 


### PR DESCRIPTION
Doing this for the tech talk, looks like we didn't have a link to staff hours from the docs before, strangely enough.

Pretty **cool** stuff yo!