### PR TITLE
docs: Update mail forwarding and vhost info

### DIFF
--- a/ocfweb/docs/docs/services/mail.md
+++ b/ocfweb/docs/docs/services/mail.md
@@ -1,21 +1,26 @@
 [[!meta title="Email"]]
+
+Email sent to your username @ocf.berkeley.edu (e.g.
+`username@ocf.berkeley.edu`) will be forwarded to a contact email address of
+your choosing.
+
+To configure a forwarding address, log in via [[SSH|doc services/shell]] and
+enter the `update-email` command to view or update your contact email address.
+
+Note that you are required to keep your contact address up-to-date for as long
+as you continue to use your account. If you cannot be reached by your contact
+address, your account is liable to be disabled.
+
 ## Student groups
 
-We provide email hosting for student groups who have a
-[[virtual host|doc services/vhost]] (e.g. mygroup.berkeley.edu).
-
-We're working on improving our mail offering for student groups to support
-additional features; in the mean-time, only mail forwarding is supported. See
-[[here|doc services/vhost#email]] for instructions on configuring a forwarding
-address.
+We provide email virtual hosting for student groups who have a [[virtual
+host|doc services/vhost]] (e.g. mygroup.berkeley.edu). See [[here|doc
+services/vhost/mail]] for instructions on requesting email hosting and
+configuring email addresses.
 
 ## Individual accounts
 
-Mail service for individual accounts was discontinued over summer 2014. We are
-offering mail forwarding for a limited time, but this will cease to work in the
-future (date TBD).
-
-To configure a forwarding address, log in via [[SSH|doc services/shell]] and enter the
-`update-email` command to view or update your register email address.
+Mail service for individual accounts was discontinued over summer 2014, but we
+are still offering email forwarding for individual accounts indefinitely.
 
 Note that sending mail from your individual OCF account is no longer possible.


### PR DESCRIPTION
In particular, updating your contact email address via update-email is required
of both student groups and individual accounts.