### PR TITLE
docs: linewrap everything

### DIFF
--- a/ocfweb/docs/docs/about.md
+++ b/ocfweb/docs/docs/about.md
@@ -2,52 +2,49 @@
 
 ## The mission
 
-The OCF is an all-volunteer, student-run, Chartered Program of the
-[Associated Students of the University of California (ASUC)][asuc]
-dedicated to free computing for all [University of California at
-Berkeley][berkeley] students, faculty, and staff.  The mission of the OCF is to
-provide an environment where no member of Berkeley's campus community is denied
-the computer resources he or she seeks, and to appeal to all members of the
-Berkeley campus community with unsatisfied computing needs and to provide a
-place for those interested in computing to fully explore that interest.
+The OCF is an all-volunteer, student-run, Chartered Program of the [Associated
+Students of the University of California (ASUC)][asuc] dedicated to free
+computing for all [University of California at Berkeley][berkeley] students,
+faculty, and staff.  The mission of the OCF is to provide an environment where
+no member of Berkeley's campus community is denied the computer resources he or
+she seeks, and to appeal to all members of the Berkeley campus community with
+unsatisfied computing needs and to provide a place for those interested in
+computing to fully explore that interest.
 
 ## What do we do?
 
 The Open Computing Facility provides free computing services to student,
-faculty, and staff, ranging from printing to expiration-free web
-space to Unix shell accounts to email. Furthermore, the OCF operates a
-highly frequented long-hours computing lab with a generally high
-volunteer-staff-to-user ratio for accessible in-person support, as well
-as online support. In addition to these user services, the group also
-hosts numerous student group websites, and provides support to these and
-other organizations on campus.
+faculty, and staff, ranging from printing to expiration-free web space to Unix
+shell accounts to email. Furthermore, the OCF operates a highly frequented
+long-hours computing lab with a generally high volunteer-staff-to-user ratio
+for accessible in-person support, as well as online support. In addition to
+these user services, the group also hosts numerous student group websites, and
+provides support to these and other organizations on campus.
 
-To be able to do this, we are always aiming to secure more resources to
-fully meet the needs of everyone in the campus community.  Our primary
-resources are our GNU/Linux workstations and servers, entirely
-administered by [[student volunteers|doc staff]].
-These resources are located within our computing lab on the ground floor of MLK
-Student Union.
+To be able to do this, we are always aiming to secure more resources to fully
+meet the needs of everyone in the campus community.  Our primary resources are
+our GNU/Linux workstations and servers, entirely administered by [[student
+volunteers|doc staff]]. These resources are located within our computing lab on
+the ground floor of MLK Student Union.
 
 To help people explore the field of computing and educate them about the
 resources available, the OCF also provides a variety of educational services.
 We used to co-sponsor a series of Help Sessions, short classes taught
 throughout the semester on a wide range of computing topics, from beginner to
 advanced levels, and focusing on resources available to the Berkeley campus
-community.  These now take the form of [DeCal
-courses][decal] offered by us. We also offer e-mail and
-in-person consulting with our volunteer staff members, as well as online
-sources of information about computing on the Berkeley campus and how to use
-the available resources.  Additionally, the OCF has conducted career fairs in
-the past with its sister organization, the [Computer Science Undergraduate
-Association][csua].
+community.  These now take the form of [DeCal courses][decal] offered by us. We
+also offer e-mail and in-person consulting with our volunteer staff members, as
+well as online sources of information about computing on the Berkeley campus
+and how to use the available resources.  Additionally, the OCF has conducted
+career fairs in the past with its sister organization, the [Computer Science
+Undergraduate Association][csua].
 
-Policies for this cluster and decisions for the OCF organization are made
-by the OCF Board of Directors, a group of students elected each semester
-by the OCF membership.  The Board meetings, held at least once every two
-weeks when classes are in session, are open to the public and provide a
-chance for any user to express their concerns or opinions about the OCF.
-[Minutes of previous meetings][minutes] are also available online.
+Policies for this cluster and decisions for the OCF organization are made by
+the OCF Board of Directors, a group of students elected each semester by the
+OCF membership.  The Board meetings, held at least once every two weeks when
+classes are in session, are open to the public and provide a chance for any
+user to express their concerns or opinions about the OCF. [Minutes of previous
+meetings][minutes] are also available online.
 
 ## How to find us
 
@@ -57,9 +54,9 @@ map, see [[here|doc services/lab]].
 If you need to contact OCF staff members, you may [[send us an email|doc
 contact]]
 
-The Open Computing Facility is a student group acting independently of
-the University of California.  We take full responsibility for our
-organization and this website.
+The Open Computing Facility is a student group acting independently of the
+University of California.  We take full responsibility for our organization and
+this website.
 
 [asuc]: http://asuc.org
 [berkeley]: http://berkeley.edu

--- a/ocfweb/docs/docs/contact.md
+++ b/ocfweb/docs/docs/contact.md
@@ -2,16 +2,16 @@
 
 > ## Before contacting us
 > Please conserve our valuable volunteer manpower by **making sure your
-> question isn't already answered in our [[Frequently asked questions|doc faq]]**.
+> question isn't already answered in our [[Frequently asked questions|doc
+> faq]]**.
 >
-> *Interested in [[joining staff|about-staff]]? Feel free to
-> attend our meetings or contact us by email!*
+> *Interested in [[joining staff|about-staff]]? Feel free to attend our
+> meetings or contact us by email!*
 
 There are several ways to contact the student volunteers who keep the OCF
 running (hereafter referred to as OCF staff). If your question cannot be
 answered by the **[[FAQ|doc faq]]**, we ask that you try coming to **[[staff
-hours|staff-hours]]** before contacting us by
-email.
+hours|staff-hours]]** before contacting us by email.
 
 When contacting OCF staff, please reference
 
@@ -32,8 +32,8 @@ with an OCF volunteer staffer, check the [[posted staff hours|staff-hours]].
 Please do **not** send us your password over email, or your account will be
 disabled.
 
-**Do not email us about items lost in the lab.** The front desk is staffed
-by paid employees, not by OCF volunteers. If you email us, the front desk staff
+**Do not email us about items lost in the lab.** The front desk is staffed by
+paid employees, not by OCF volunteers. If you email us, the front desk staff
 *will not see it*. If you've lost something, you should instead stop by
 in-person to ask for it.
 
@@ -70,19 +70,19 @@ Our address is:
 
 ## Legal
 
-Use of OCF resources in violation of applicable
-[university policies][usepolicy] and laws, including copyright, spam, and
-fraud, is not allowed. Accounts of repeat infringers will be disabled in
-accordance with university policies.
+Use of OCF resources in violation of applicable [university
+policies][usepolicy] and laws, including copyright, spam, and fraud, is not
+allowed. Accounts of repeat infringers will be disabled in accordance with
+university policies.
 
 DMCA takedown notices must comply with [17 U.S.C. § 512(c)(3)][dmca] and be
-sent to the [designated agent at UC Berkeley][dmca]. We recommend also sending a
-copy of the notice to the OCF directly
+sent to the [designated agent at UC Berkeley][dmca]. We recommend also sending
+a copy of the notice to the OCF directly
 ([security@ocf.berkeley.edu](mailto:security@ocf.berkeley.edu)) for faster
 response.
 
-Please note that any cease and desist notices may be forwarded to the
-[Lumen database][lumen] for publication and annotation.
+Please note that any cease and desist notices may be forwarded to the [Lumen
+database][lumen] for publication and annotation.
 
 [lumen]: https://lumendatabase.org/
 [dmca]: https://security.berkeley.edu/digital-millennium-copyright-act-dmca-uc-berkeley

--- a/ocfweb/docs/docs/contact/irc.md
+++ b/ocfweb/docs/docs/contact/irc.md
@@ -14,17 +14,17 @@ You have three simple options for chatting:
 
 We have a web client set up at [irc.ocf.berkeley.edu][webirc] using the popular
 open-source web client [The Lounge][thelounge]. It's already set up with our
-IRC network settings, so all you need to do is enter a nickname that you want to
-use and click the connect button at the bottom. You can enter your real name if
-you want, but it's not required. Once connected, you can type messages in the
-bottom bar and press enter and the OCF staff connected will respond to you as
-soon as we see your messages.
+IRC network settings, so all you need to do is enter a nickname that you want
+to use and click the connect button at the bottom. You can enter your real name
+if you want, but it's not required. Once connected, you can type messages in
+the bottom bar and press enter and the OCF staff connected will respond to you
+as soon as we see your messages.
 
 ### Option 2: Using your own client
 
 You can connect using any IRC client. If you do not already have an IRC client,
-we recommend using [Hexchat][hexchat] because it is free,
-open source, and generally easy to use. Our server settings are listed below:
+we recommend using [Hexchat][hexchat] because it is free, open source, and
+generally easy to use. Our server settings are listed below:
 
 * **Server:** `irc.ocf.berkeley.edu`
 * **Port:** `6697` (requires SSL/TLS)
@@ -34,8 +34,8 @@ open source, and generally easy to use. Our server settings are listed below:
 
 If you're logged in to the OCF login server via [[SSH|doc services/shell]], you
 can use the pyrc script to easily connect to IRC. It will automatically launch
-a tmux session to contain your IRC session, so that you aren't disconnected when
-you close the terminal.
+a tmux session to contain your IRC session, so that you aren't disconnected
+when you close the terminal.
 
 To do so, just type `pyrc` and hit enter. irssi will launch; press alt +
 left/right to switch which channel you're viewing.
@@ -47,23 +47,23 @@ and reconnecting again, you can register with NickServ.
 
 ### Registering with NickServ
 
-To register with NickServ, choose a password and enter the command
-`/msg NickServ register [password] [email]` into your IRC client. NickServ
-should reply after you run the registration command that you have been
-registered with your email. To see if you are registered properly, try running
-`/msg NickServ info`. You should see your email address, and where you are logged
-in from, among other results.
+To register with NickServ, choose a password and enter the command `/msg
+NickServ register [password] [email]` into your IRC client. NickServ should
+reply after you run the registration command that you have been registered with
+your email. To see if you are registered properly, try running `/msg NickServ
+info`. You should see your email address, and where you are logged in from,
+among other results.
 
 ### Setting up NickServ to work with ZNC
 
-If you are [[using ZNC|doc staff/staffvm/znc]], load the
-[NickServ module][nickserv] by running `/znc LoadMod nickserv` while connected
-to your ZNC server. Then, in your ZNC web admin interface, log in and go to
-`Your Settings` under either the global or user modules links. Under the
-Networks section, click on the `Edit` link next to the OCF network and scroll
-down to the Modules section. Enable the `nickserv` module and type the password
-you used to register with NickServ into the arguments box. Then save your
-changes using the button at the bottom of the page and ZNC should automatically
+If you are [[using ZNC|doc staff/staffvm/znc]], load the [NickServ
+module][nickserv] by running `/znc LoadMod nickserv` while connected to your
+ZNC server. Then, in your ZNC web admin interface, log in and go to `Your
+Settings` under either the global or user modules links. Under the Networks
+section, click on the `Edit` link next to the OCF network and scroll down to
+the Modules section. Enable the `nickserv` module and type the password you
+used to register with NickServ into the arguments box. Then save your changes
+using the button at the bottom of the page and ZNC should automatically
 authenticate with NickServ if you get disconnected from ZNC.
 
 [webirc]: https://irc.ocf.berkeley.edu

--- a/ocfweb/docs/docs/docs/charter.md
+++ b/ocfweb/docs/docs/docs/charter.md
@@ -1,6 +1,7 @@
 [[!meta title="Charter"]]
 
 
-The OCF is an ASUC Chartered Program; the authoritative text of its charter can be found at
-[section 3204](https://docs.google.com/document/d/1bZhThJoNRUFOAX_gntXd4fgUSZkmfvCbOCr8p5Am75s/)
+The OCF is an ASUC Chartered Program; the authoritative text of its charter can
+be found at [section
+3204](https://docs.google.com/document/d/1bZhThJoNRUFOAX_gntXd4fgUSZkmfvCbOCr8p5Am75s/)
 of the ASUC bylaws.

--- a/ocfweb/docs/docs/docs/operatingrules.md
+++ b/ocfweb/docs/docs/docs/operatingrules.md
@@ -4,5 +4,6 @@
 The Operating Rules of the OCF consist of the Constitution and the Bylaws. The
 Constitution's provisions hold precedence over the Bylaws.
 
- - [[Constitution of the Open Computing Facility|doc docs/operatingrules/constitution]]
+ - [[Constitution of the Open Computing Facility|doc
+   docs/operatingrules/constitution]]
  - [[Bylaws of the Open Computing Facility|doc docs/operatingrules/bylaws]]

--- a/ocfweb/docs/docs/docs/operatingrules/bylaws.md
+++ b/ocfweb/docs/docs/docs/operatingrules/bylaws.md
@@ -1,70 +1,115 @@
 [[!meta title="Bylaws"]]
 
 
-These are the official **Bylaws of the Open Computing Facility**, as last amended at the Board meeting of October 17, 2016.
+These are the official **Bylaws of the Open Computing Facility**, as last
+amended at the Board meeting of October 17, 2016.
 
-1. The General Manager and the Site Managers cannot appoint directors unless: (a) the OCF is not formally in session, and (b) the Board of Directors cannot achieve quorum because there are fewer than five directors in town.
+1. The General Manager and the Site Managers cannot appoint directors unless:
+   (a) the OCF is not formally in session, and (b) the Board of Directors
+   cannot achieve quorum because there are fewer than five directors in town.
 
-2. The OCF Board of Directors shall meet at least once every two weeks while the OCF is formally in session.
+2. The OCF Board of Directors shall meet at least once every two weeks while
+   the OCF is formally in session.
 
-3. Any Director appointed to the Board by the Decision Making Process missing two consecutive regularly scheduled meetings will be removed from the Board, regardless of whether the meetings achieve quorum.
+3. Any Director appointed to the Board by the Decision Making Process missing
+   two consecutive regularly scheduled meetings will be removed from the Board,
+   regardless of whether the meetings achieve quorum.
 
-4. OCF Board meetings must be announced to all Directors at least twenty-four hours in advance.
+4. OCF Board meetings must be announced to all Directors at least twenty-four
+   hours in advance.
 
-5. Resolutions by the Board of Directors can be put to a vote electronically. When putting a resolution to the Board in this manner, all Board members must be included in the request for votes. To pass an issue this way, at least half of all the Board members must agree. If the motion fails to achieve a majority within seventy-two hours of being called to such a vote, the motion fails. The results of the vote will be posted in roll call form.
+5. Resolutions by the Board of Directors can be put to a vote electronically.
+   When putting a resolution to the Board in this manner, all Board members
+   must be included in the request for votes. To pass an issue this way, at
+   least half of all the Board members must agree. If the motion fails to
+   achieve a majority within seventy-two hours of being called to such a vote,
+   the motion fails. The results of the vote will be posted in roll call form.
 
-6. Attendance lists and minutes for all OCF meetings shall be maintained for the decisions of that meeting to be valid.
+6. Attendance lists and minutes for all OCF meetings shall be maintained for
+   the decisions of that meeting to be valid.
 
-7. BoD appointments will take effect at 12:00 midnight after the conclusion of the meeting at which the appointment took place, with the exception of an Election Meeting.
+7. BoD appointments will take effect at 12:00 midnight after the conclusion of
+   the meeting at which the appointment took place, with the exception of an
+   Election Meeting.
 
-8. _Ex officio_ members of the Board, with the exception of elected Managers, shall not be included when calculating the necessary number of Directors present to reach quorum.
+8. _Ex officio_ members of the Board, with the exception of elected Managers,
+   shall not be included when calculating the necessary number of Directors
+   present to reach quorum.
 
 9. The Cabinet
 
-   1. The Cabinet of the Open Computing Facility shall consist of the General Manager, Site Manager, and Deputy Managers.
+   1. The Cabinet of the Open Computing Facility shall consist of the General
+      Manager, Site Manager, and Deputy Managers.
 
    2. The General Manager shall be chair of the cabinet.
 
 10. Deputy Managers
 
-   1. Deputy Managers shall be appointed and removed by the General Manager or Site Manager, subject to the OCF Decision Making Process.
+   1. Deputy Managers shall be appointed and removed by the General Manager or
+      Site Manager, subject to the OCF Decision Making Process.
 
-   2. Deputy General Managers and Deputy Site Managers shall be _ex officio_ Deputy Managers.
+   2. Deputy General Managers and Deputy Site Managers shall be _ex officio_
+      Deputy Managers.
 
-   3. The authority of Deputy Managers derives jointly from the General Manager and Site Manager, and their actions can be overruled by either the General Manager or the Site Manager.
+   3. The authority of Deputy Managers derives jointly from the General Manager
+      and Site Manager, and their actions can be overruled by either the
+      General Manager or the Site Manager.
 
 11. Deputy General Managers
 
-   1. Deputy General Managers shall be appointed and removed by the General Manager, subject to the OCF Decision Making Process.
+   1. Deputy General Managers shall be appointed and removed by the General
+      Manager, subject to the OCF Decision Making Process.
 
-   2. Deputy General Managers shall assist the General Manager with his or her duties.
+   2. Deputy General Managers shall assist the General Manager with his or her
+      duties.
 
-   3. The term of office of a Deputy General Manager shall expire at the next election of a General Manager.
+   3. The term of office of a Deputy General Manager shall expire at the next
+      election of a General Manager.
 
-   4. The resignation, dismissal, or completion of term of a Deputy General Manager shall not apply to their status as a Deputy Manager.
+   4. The resignation, dismissal, or completion of term of a Deputy General
+      Manager shall not apply to their status as a Deputy Manager.
 
 12. Deputy Site Managers
 
-   1. Deputy Site Managers shall be appointed and removed by the Site Manager, subject to the OCF Decision Making Process.
+   1. Deputy Site Managers shall be appointed and removed by the Site Manager,
+      subject to the OCF Decision Making Process.
 
-   2. Deputy Site Managers shall assist the Site Manager with his or her duties.
+   2. Deputy Site Managers shall assist the Site Manager with his or her
+      duties.
 
-   3. The term of office of a Deputy Site Manager shall expire at the next election of a Site Manager.
+   3. The term of office of a Deputy Site Manager shall expire at the next
+      election of a Site Manager.
 
-   4. The resignation, dismissal, or completion of term of a Deputy Site Manager shall not apply to their status as a Deputy Manager.
+   4. The resignation, dismissal, or completion of term of a Deputy Site
+      Manager shall not apply to their status as a Deputy Manager.
 
 13. Officers
 
    1. All Cabinet members shall be Officers of the Open Computing Facility.
 
-   2. In addition, any member of the Open Computing Facility who attends an Officers’ Meeting and requests to be appointed as an Officer shall be appointed as an Officer.
+   2. In addition, any member of the Open Computing Facility who attends an
+      Officers’ Meeting and requests to be appointed as an Officer shall be
+      appointed as an Officer.
 
-   3. Officers appointed under subsection 2 of this title shall be removed from office if they miss two consecutive Officers’ Meetings without an excuse approved by the General Manager.
+   3. Officers appointed under subsection 2 of this title shall be removed from
+      office if they miss two consecutive Officers’ Meetings without an excuse
+      approved by the General Manager.
 
-14. No person shall be appointed as a Director unless they have served previously on the Board of Directors or have attended at least four Board meetings in the semester in which they are to be appointed.
+14. No person shall be appointed as a Director unless they have served
+    previously on the Board of Directors or have attended at least four Board
+    meetings in the semester in which they are to be appointed.
 
-    Any non-Director member who attends four Board meetings in the same semester can request to be appointed as a Director; they shall be automatically appointed unless a Director moves for a vote on their appointment, in which case the candidate will be appointed upon gaining a majority vote.
+    Any non-Director member who attends four Board meetings in the same
+    semester can request to be appointed as a Director; they shall be
+    automatically appointed unless a Director moves for a vote on their
+    appointment, in which case the candidate will be appointed upon gaining a
+    majority vote.
 
-    Directors not in good standing shall be disqualified from the Board until they are in good standing again.
+    Directors not in good standing shall be disqualified from the Board until
+    they are in good standing again.
 
-Bylaws 1-4 amended at the general meeting of March 21, 2008. Bylaws 5-6 from the revision of the bylaws last amended February 7, 1995. Bylaw 8 added at the Board meeting of April 30, 2014. Bylaws 9-13 added at the Board meeting of October 10, 2016. Bylaw 14 added at the Board meeting of October 17, 2016. Bylaw 7 amended at the Board meeting of October 31, 2016.
+Bylaws 1--4 amended at the general meeting of March 21, 2008. Bylaws 5--6 from
+the revision of the bylaws last amended February 7, 1995. Bylaw 8 added at the
+Board meeting of April 30, 2014. Bylaws 9--13 added at the Board meeting of
+October 10, 2016. Bylaw 14 added at the Board meeting of October 17, 2016.
+Bylaw 7 amended at the Board meeting of October 31, 2016.

--- a/ocfweb/docs/docs/faq.md
+++ b/ocfweb/docs/docs/faq.md
@@ -9,9 +9,12 @@ More specifically, we have a [[list of services|doc services]].
 
 #### Who are you?
 
-The largest(\*) student organization on campus (\*by membership count). OCF is completely administered and operated by student volunteers ("staff"). [[About the OCF|doc about]].
+The largest(\*) student organization on campus (\*by membership count). OCF is
+completely administered and operated by student volunteers ("staff"). [[About
+the OCF|doc about]].
 
-Interested in [[joining staff|about-staff]]? Feel free to attend our meetings or [[contact us|doc contact]] by email.
+Interested in [[joining staff|about-staff]]? Feel free to attend our meetings
+or [[contact us|doc contact]] by email.
 
 #### Where is the lab? What are the hours?
 
@@ -33,9 +36,8 @@ manually approved. If this was the case, you will have been informed during
 account creation.
 
 In most cases when people think their account has not been created, the email
-landed in their spam folder. Check that first, or try to
-[[reset your password|change_password]] to see if your account has been
-created.
+landed in their spam folder. Check that first, or try to [[reset your
+password|change_password]] to see if your account has been created.
 
 #### I think I left something in the lab, can you tell me if it's there?
 
@@ -46,7 +48,8 @@ by in-person to ask for it.
 
 #### I have an account. Does it expire? Will it still work?
 
-It should still work. Our current policy is to leave accounts alone after graduation. See [[account|doc services/account]].
+It should still work. Our current policy is to leave accounts alone after
+graduation. See [[account|doc services/account]].
 
 #### My account is disabled. Or, I want to disable or delete my account.
 
@@ -58,7 +61,9 @@ See [[account|doc services/account]].
 
 #### [[Web hosting|doc services/web]]: How do I get group.berkeley.edu ([[virtual hosting|doc services/vhost]])?
 
-First, you need to have a group [[account|doc membership]] and a working [[website|doc services/web]]. Then, request [[virtual hosting|doc services/vhost]].
+First, you need to have a group [[account|doc membership]] and a working
+[[website|doc services/web]]. Then, request [[virtual hosting|doc
+services/vhost]].
 
 #### [[Printing|doc services/lab/printing]]: I have a printing question/problem.
 

--- a/ocfweb/docs/docs/membership.md
+++ b/ocfweb/docs/docs/membership.md
@@ -2,31 +2,44 @@
 
 ## Before you begin
 
-* Check the [[membership eligibility|doc membership/eligibility]] page to make sure you are eligible for an OCF account. For example, all currently-enrolled students and active student groups registered with the LEAD Center are eligible.
+* Check the [[membership eligibility|doc membership/eligibility]] page to make
+  sure you are eligible for an OCF account. For example, all currently-enrolled
+  students and active student groups registered with the LEAD Center are
+  eligible.
 
-* OCF accounts do not expire, so make sure you have not made an account in the past. If you have forgotten your account name or password, please do not request a new account. Instead, reset your [[password|doc services/account]].
+* OCF accounts do not expire, so make sure you have not made an account in the
+  past. If you have forgotten your account name or password, please do not
+  request a new account. Instead, reset your [[password|doc services/account]].
 
-* Choose an OCF account name that is based on your real name (for individual accounts) or your group's name (for group accounts). It is unlikely you will be able to change your account name after your request has been processed.
+* Choose an OCF account name that is based on your real name (for individual
+  accounts) or your group's name (for group accounts). It is unlikely you will
+  be able to change your account name after your request has been processed.
 
 ## Individual accounts
 
-* Individual accounts are associated with a single person and may not be shared.
-* Individual accounts are **not** eligible for [[virtual hosting|doc services/vhost]].
+* Individual accounts are associated with a single person and may not be
+  shared.
+* Individual accounts are **not** eligible for [[virtual hosting|doc
+  services/vhost]].
 * Individual accounts are eligible for [[printing|doc services/lab/printing]].
 
 **[[Request an account online|register]]**
 
-  You will be prompted to log in with CalNet. Then follow the instructions to make your request. Your account name must be based on your real name.
+You will be prompted to log in with CalNet. Then follow the instructions to
+make your request. Your account name must be based on your real name.
 
-  Feel free to [[contact us|doc contact]] if you experience difficulties in the request or you have questions.
+Feel free to [[contact us|doc contact]] if you experience difficulties in the
+request or you have questions.
 
 Then, wait for your account to be created. (below)
 
 ## Group accounts
 
-* Group accounts are associated with a group and may be shared by members of the group.
+* Group accounts are associated with a group and may be shared by members of
+  the group.
 * Group accounts are eligible for [[virtual hosting|doc services/vhost]].
-* Group accounts are **not** eligible for [[printing|doc services/lab/printing]].
+* Group accounts are **not** eligible for [[printing|doc
+  services/lab/printing]].
 
 Follow this procedure to get a group account:
 

--- a/ocfweb/docs/docs/membership/banning.md
+++ b/ocfweb/docs/docs/membership/banning.md
@@ -2,8 +2,17 @@
 
 <!-- As established by BoD on October 31, 2016 -->
 
-Any member of the OCF staff may propose to ban a user from the OCF for willful violation of OCF policies. Banned users may not enter the OCF lab or use any OCF services.
+Any member of the OCF staff may propose to ban a user from the OCF for willful
+violation of OCF policies. Banned users may not enter the OCF lab or use any
+OCF services.
 
-Once a user is proposed to be banned, all staff with any involvement with the user will be called to the next Board of Directors meeting, and those present shall testify. The Board of Directors may then decide to ban the user with a ⅔ majority vote.
+Once a user is proposed to be banned, all staff with any involvement with the
+user will be called to the next Board of Directors meeting, and those present
+shall testify. The Board of Directors may then decide to ban the user with a ⅔
+majority vote.
 
-If the user is banned, they shall be promptly notified of the ban and given a chance to appeal the ban at a future Board of Directors meeting. At that meeting, they will be asked to explain their actions. The Board of Directors then may decide with a ⅔ majority vote by secret ballot to uphold the ban; if the ban is not upheld, it shall be rescinded.
+If the user is banned, they shall be promptly notified of the ban and given a
+chance to appeal the ban at a future Board of Directors meeting. At that
+meeting, they will be asked to explain their actions. The Board of Directors
+then may decide with a ⅔ majority vote by secret ballot to uphold the ban; if
+the ban is not upheld, it shall be rescinded.

--- a/ocfweb/docs/docs/membership/eligibility.md
+++ b/ocfweb/docs/docs/membership/eligibility.md
@@ -3,7 +3,10 @@
 The following individuals and groups are eligible for [[membership|doc membership]]:
 
 
-The Open Computing Facility provides accounts and services to members. Members must meet at least one of the following eligibility criteria during account creation as verified electronically **or** by presentation of the specified documentation:
+The Open Computing Facility provides accounts and services to members. Members
+must meet at least one of the following eligibility criteria during account
+creation as verified electronically **or** by presentation of the specified
+documentation:
 
 ## Individuals
 
@@ -29,8 +32,8 @@ The Open Computing Facility provides accounts and services to members. Members m
 
 * Current LBNL ID card
 
-### Mathematical Sciences Research Institute (MSRI)
-(postdoc researchers and research professors)
+### Mathematical Sciences Research Institute (MSRI) (postdoc researchers and
+research professors)
 
 * Letter from your department on departmental letterhead stating:
   * Your name
@@ -44,6 +47,7 @@ The Open Computing Facility provides accounts and services to members. Members m
 * Current student ID card
 
 ### UC Berkeley Extension students
+
 (students enrolled in certificate programs or concurrently enrolled in a course offered by UC Berkeley)
 
 At least one of the following:
@@ -57,10 +61,14 @@ At least one of the following:
 
 ### UC Berkeley Extension faculty
 
-* Letter of appointment marked as independent contractor by agreement for a term
+* Letter of appointment marked as independent contractor by agreement for a
+  term
 
 ### Employees of other University-affiliated organizations
-(employees who work on UC Berkeley campus (e.g. California Alumni Association, International House, Howard Hughes Medical Institute) or closely associated with the campus (e.g. Richmond Field Station))
+
+(employees who work on UC Berkeley campus (e.g. California Alumni Association,
+International House, Howard Hughes Medical Institute) or closely associated
+with the campus (e.g. Richmond Field Station))
 
 * Letter from your organization or unit stating:
   * Your name
@@ -70,6 +78,7 @@ At least one of the following:
   * Signer's contact information for verification purposes
 
 ### Volunteers, contractors, and other individuals
+
 (people who work on UC Berkeley campus supporting the University)
 
 * Letter from your department on departmental letterhead stating:
@@ -83,6 +92,11 @@ At least one of the following:
 
 Current Cal ID and at least one of the following:
 
-* Signatory position in an active student group on [CalLink](https://callink.berkeley.edu/)
-* Letter from your department on departmental letterhead stating departmental recognition of the group and departmental support for obtaining the group account
-* Documentation establishing that the Chancellor has recognized the group as a support organization and that the person requesting the account is authorized to make the request
+* Signatory position in an active student group on
+  [CalLink](https://callink.berkeley.edu/)
+* Letter from your department on departmental letterhead stating departmental
+  recognition of the group and departmental support for obtaining the group
+  account
+* Documentation establishing that the Chancellor has recognized the group as a
+  support organization and that the person requesting the account is authorized
+  to make the request

--- a/ocfweb/docs/docs/services.md
+++ b/ocfweb/docs/docs/services.md
@@ -2,4 +2,5 @@
 
 The OCF offers many services, free of charge, to the campus community.
 
-Have an idea for something else the OCF can provide? Feel free to send your suggestion by [[contacting us|doc contact]]!
+Have an idea for something else the OCF can provide? Feel free to send your
+suggestion by [[contacting us|doc contact]]!

--- a/ocfweb/docs/docs/services/account.md
+++ b/ocfweb/docs/docs/services/account.md
@@ -3,15 +3,23 @@
 
 ## Introduction
 
-Your OCF account is both proof of your [[membership|doc membership]] and the means by which you authenticate to the variety of [[services|doc services]] operated by OCF [[staff|doc staff]]. Your OCF account is independent from CalNet. (Technical info: public account information and salted password hashes are stored in [[LDAP|doc staff/backend/ldap]] and [[Kerberos|doc staff/backend/kerberos]] databases, respectively.)
+Your OCF account is both proof of your [[membership|doc membership]] and the
+means by which you authenticate to the variety of [[services|doc services]]
+operated by OCF [[staff|doc staff]]. Your OCF account is independent from
+CalNet. (Technical info: public account information and salted password hashes
+are stored in [[LDAP|doc staff/backend/ldap]] and [[Kerberos|doc
+staff/backend/kerberos]] databases, respectively.)
 
-Accounts are not normally deactivated after your membership
-[[eligibility|doc membership/eligibility]] expires (e.g., graduation). In fact, we have active
+Accounts are not normally deactivated after your membership [[eligibility|doc
+membership/eligibility]] expires (e.g., graduation). In fact, we have active
 accounts dating back to at least 1995.
 
 ## Passwords
 
-OCF staff members **do not need to know your password**. In fact, we can't "look it up" either since we don't store your password directly but rather a salted [cryptographic hash](https://en.wikipedia.org/wiki/Cryptographic_hash_function).
+OCF staff members **do not need to know your password**. In fact, we can't
+"look it up" either since we don't store your password directly but rather a
+salted [cryptographic
+hash](https://en.wikipedia.org/wiki/Cryptographic_hash_function).
 
 Email is generally insecure, so please **do not send passwords over email**. We
 don't want to know it, and we have to disable your account if you tell it to
@@ -21,9 +29,8 @@ us!
 
 #### Using CalNet
 
-You can [[find your username or reset your password
-online|change_password]] using CalNet
-(assuming you have CalNet access).
+You can [[find your username or reset your password online|change_password]]
+using CalNet (assuming you have CalNet access).
 
 To reset the password for a group account, you need to be a registered
 signatory for the group. If your group isn't registered with the LEAD Center
@@ -34,7 +41,9 @@ signatory for the group. If your group isn't registered with the LEAD Center
 
 You can change your password over SSH if you know your current password.
 
-Use [[SSH|doc services/shell]] to run the command `passwd` and follow the prompts as shown below. No text will appear when you are entering in a password, just press enter when done after each prompt.
+Use [[SSH|doc services/shell]] to run the command `passwd` and follow the
+prompts as shown below. No text will appear when you are entering in a
+password, just press enter when done after each prompt.
 
 ```text
 $ passwd
@@ -46,9 +55,13 @@ Success : Password changed
 
 #### In person
 
-If you are not able to use CalNet or SSH, if you are a group and forgot your current password), you can meet a staff member in person during [[staff hours|staff-hours]].
+If you are not able to use CalNet or SSH, if you are a group and forgot your
+current password), you can meet a staff member in person during [[staff
+hours|staff-hours]].
 
-Please bring sufficient documentation as listed on the [[membership eligibility|doc membership/eligibility]] page to demonstrate that you are authorized to reset the account password.
+Please bring sufficient documentation as listed on the [[membership
+eligibility|doc membership/eligibility]] page to demonstrate that you are
+authorized to reset the account password.
 
 #### Manual verification of identity (typically for alumni with old accounts)    {manual-reset}
 
@@ -79,19 +92,26 @@ For security purposes, please include the following with your request:
 * a second piece of supporting ID (such as driver's license)
 
 * a signed, dated statement to the effect of:
-> I, John Doe, authorize Open Computing Facility staff to reset my password. Enclosed is a copy of my ID.
+  > I, John Doe, authorize Open Computing Facility staff to reset my password.
+  > Enclosed is a copy of my ID.
 
-* contact information so that we can notify you when your password reset has been processed
+* contact information so that we can notify you when your password reset has
+  been processed
 
-If you no longer have your Cal ID, you may substitute it with another government-issued ID.
+If you no longer have your Cal ID, you may substitute it with another
+government-issued ID.
 
 ### MySQL
 
-Access to your [[MySQL database|doc services/mysql]], if you have one, is protected by a separate password.
+Access to your [[MySQL database|doc services/mysql]], if you have one, is
+protected by a separate password.
 
 ## After graduation
 
-Currently, we don't actively disable accounts, so you are free to use your account until that policy changes. We can't promise all of your OCF account privileges into perpetuity, however.  We are run by students volunteers using student money.
+Currently, we don't actively disable accounts, so you are free to use your
+account until that policy changes. We can't promise all of your OCF account
+privileges into perpetuity, however.  We are run by students volunteers using
+student money.
 
 ## Disabled accounts
 
@@ -101,8 +121,14 @@ Some common reasons accounts are disabled:
  * security (e.g., account hijacked)
  * misuse (e.g., excessive use of resources, violation of University policies)
 
-Accounts may also be disabled if OCF staff need to contact you but cannot do so.
+Accounts may also be disabled if OCF staff need to contact you but cannot do
+so.
 
-To re-enable your account, you will need to see a Manager during [[staff hours|staff-hours]].
+To re-enable your account, you will need to see a Manager during [[staff
+hours|staff-hours]].
 
-If you want to disable your OCF account, please [[contact us|doc contact]] and provide your OCF username. If your account appears to still be active, we may ask for some evidence that you are the account owner. Currently, disabled accounts are stored or archived and can be *re-enabled* by request at a later date. Disabled accounts may eventually be scheduled for deletion.
+If you want to disable your OCF account, please [[contact us|doc contact]] and
+provide your OCF username. If your account appears to still be active, we may
+ask for some evidence that you are the account owner. Currently, disabled
+accounts are stored or archived and can be *re-enabled* by request at a later
+date. Disabled accounts may eventually be scheduled for deletion.

--- a/ocfweb/docs/docs/services/lab/printing.md
+++ b/ocfweb/docs/docs/services/lab/printing.md
@@ -1,6 +1,8 @@
 [[!meta title="Printing"]]
 
-The OCF offers a certain amount of printing to individual members. You don't have to request a new account each semester - the quota is refreshed at the start of each semester.
+The OCF offers a certain amount of printing to individual members. You don't
+have to request a new account each semester - the quota is refreshed at the
+start of each semester.
 
 Printing is currently limited to:
 
@@ -11,7 +13,8 @@ Printing is currently limited to:
 Please note:
 
  * Each **printed side** of a sheet counts as a page.
- * Jobs take time to process proportional to the job size.  If you submit a large job, please be patient while the print server processes it.
+ * Jobs take time to process proportional to the job size.  If you submit a
+   large job, please be patient while the print server processes it.
 
 
 ## Remaining quota

--- a/ocfweb/docs/docs/services/mysql.md
+++ b/ocfweb/docs/docs/services/mysql.md
@@ -28,7 +28,8 @@ If you are looking for a familiar phpMyAdmin interface, visit
 
 ## Creating a MySQL database
 
-We have two options to create a database using the terminal or our web management tool.
+We have two options to create a database using the terminal or our web
+management tool.
 
 
 ### Web-based tool
@@ -66,15 +67,16 @@ is a randomly generated password that was created when your database was
 created. To use your OCF MySQL database with a web application, enter the above
 information during the application's installation process.
 
-To connect to the OCF's MySQL server using the MySQL client on an OCF machine, simply run the command:
-`mysql`
+To connect to the OCF's MySQL server using the MySQL client on an OCF machine,
+simply run the command: `mysql`
 
 This command will prompt you for your MySQL database password.
 
 
 ## Backing up a MySQL database
 
-To backup your database (which you should probably do regularly), the basic command to use is
+To backup your database (which you should probably do regularly), the basic
+command to use is
 
     mysqldump [username] > backup
 

--- a/ocfweb/docs/docs/services/shell.md
+++ b/ocfweb/docs/docs/services/shell.md
@@ -1,6 +1,9 @@
 [[!meta title="Shell (SSH/SFTP)"]]
 
-A shell account refers to a text-mode interface where commands can be run interactively. All OCF accounts include shell account access. You can access your shell account over an encrypted connection in the OCF lab or remotely via SSH/SFTP.
+A shell account refers to a text-mode interface where commands can be run
+interactively. All OCF accounts include shell account access. You can access
+your shell account over an encrypted connection in the OCF lab or remotely via
+SSH/SFTP.
 
 We support the following commonly used shell account tools (to name a few):
 
@@ -8,7 +11,9 @@ We support the following commonly used shell account tools (to name a few):
 *   cron and at: execute commands on a periodic or scheduled basis
 *   vim and emacs: powerful and extensible text editors
 
-Most SSH/SFTP clients will prompt you to accept an unknown key when you first connect. Our SSH fingerprint can be used to verify that you're connecting to the correct server:
+Most SSH/SFTP clients will prompt you to accept an unknown key when you first
+connect. Our SSH fingerprint can be used to verify that you're connecting to
+the correct server:
 
     2048 55:0a:e3:4f:4b:2c:15:f8:d4:7d:f9:93:bf:a0:41:21 tsunami.ocf.berkeley.edu (RSA)
     1024 7e:19:bc:fd:b5:cd:5c:e3:42:a4:a5:74:eb:ce:5d:2e tsunami.ocf.berkeley.edu (DSA)
@@ -22,7 +27,9 @@ Your shell account can be controlled remotely using
 `ssh.ocf.berkeley.edu` (`tsunami`).
 
 #### From your browser
-If you just need to access SSH quickly, you can use our [web-based SSH interface](https://ssh.ocf.berkeley.edu/) from your web browser.
+
+If you just need to access SSH quickly, you can use our [web-based SSH
+interface](https://ssh.ocf.berkeley.edu/) from your web browser.
 
 #### Mac OS X or Linux
 
@@ -31,6 +38,7 @@ On Mac OS X or Linux, enter in the terminal:
     ssh username@ssh.ocf.berkeley.edu
 
 #### Windows
+
 On Windows, use [PuTTY][putty] (download the `putty.exe` file):
 
 * Host Name: `ssh.ocf.berkeley.edu`
@@ -42,8 +50,8 @@ On Windows, use [PuTTY][putty] (download the `putty.exe` file):
 
 You can transfer files to your account using [SFTP][sftp]. To transfer files
 you can use the command line utility `sftp`, or a graphical program such as
-[FileZilla][filezilla] (Linux, Mac, Windows), [WinSCP][winscp] (Windows),
-or [Cyberduck][cyberduck] (Mac, Windows).
+[FileZilla][filezilla] (Linux, Mac, Windows), [WinSCP][winscp] (Windows), or
+[Cyberduck][cyberduck] (Mac, Windows).
 
 [sftp]: https://en.wikipedia.org/wiki/SSH_File_Transfer_Protocol
 [filezilla]: https://filezilla-project.org/

--- a/ocfweb/docs/docs/services/vhost.md
+++ b/ocfweb/docs/docs/services/vhost.md
@@ -26,25 +26,36 @@ of the virtual-hosted site (`yourgroup.berkeley.edu`).
 
 ### Instructions
 
-1.   **Request group account.** [[Request an OCF group account|doc membership]] (if you haven't already done so).
-2.   **Set up real site.** Set up your webspace and upload your website (if you haven't already done so). The website should be developed already, not a placeholder.
-3.   **Include OCF hosting banner.** Place a [[Hosted by OCF banner|doc services/vhost/badges]] on your home page that links to the OCF front page. If none of these images are appropriate for your site, you may design one of your own and [[submit it|doc contact]] for approval.
-4.   **Include university's disclaimer.** If you are a student group, place the university-mandated student group disclaimer on each page of your website (see the section below).
-5.   **Complete request form.** Complete the [[virtual hosting request form|request_vhost]] online.
-   OCF staff will review your request and contact the university hostmaster on your
-   behalf.
+1.   **Request group account.** [[Request an OCF group account|doc membership]]
+     (if you haven't already done so).
+2.   **Set up real site.** Set up your webspace and upload your website (if you
+     haven't already done so). The website should be developed already, not a
+     placeholder.
+3.   **Include OCF hosting banner.** Place a [[Hosted by OCF banner|doc
+     services/vhost/badges]] on your home page that links to the OCF front
+     page. If none of these images are appropriate for your site, you may
+     design one of your own and [[submit it|doc contact]] for approval.
+4.   **Include university's disclaimer.** If you are a student group, place the
+     university-mandated student group disclaimer on each page of your website
+     (see the section below).
+5.   **Complete request form.** Complete the [[virtual hosting request
+     form|request_vhost]] online. OCF staff will review your request and
+     contact the university hostmaster on your behalf.
 
 ### Including the OCF banner
 
-Place any of the [[Hosted by OCF banners|doc services/vhost/badges]] on your site by copying the code onto your page. The banner is required to be placed only on the home page of your site. You can also create your own OCF banner with approval from the OCF (see instructions above).
+Place any of the [[Hosted by OCF banners|doc services/vhost/badges]] on your
+site by copying the code onto your page. The banner is required to be placed
+only on the home page of your site. You can also create your own OCF banner
+with approval from the OCF (see instructions above).
 
 ### Including the University Student Group Disclaimer    {disclaimer}
 
-The university requires that all student group websites on a subdomain of berkeley.edu contain the following text on each page:
+The university requires that all student group websites on a subdomain of
+berkeley.edu contain the following text on each page:
 
-> We are a student group acting independently of the University of
-> California. We take full responsibility for our organization and
-> this web site.
+> We are a student group acting independently of the University of California.
+> We take full responsibility for our organization and this web site.
 
 ### Policies
 
@@ -52,28 +63,48 @@ The university requires that all student group websites on a subdomain of berkel
 
 The OCF only performs virtual hosting for OCF group accounts.
 
-Each group account may have one virtual host. Requests for an exception to this rule must be approved by the OCF Board of Directors.
+Each group account may have one virtual host. Requests for an exception to this
+rule must be approved by the OCF Board of Directors.
 
 #### Limitations on non-berkeley.edu
 
-The OCF may also host non-berkeley.edu domains. The process is more complicated in this case. Permission will be granted only for group accounts that can demonstrate a unique need for having a web site outside of the berkeley.edu domain. For such domains, the group account must:
+The OCF may also host non-berkeley.edu domains. The process is more complicated
+in this case. Permission will be granted only for group accounts that can
+demonstrate a unique need for having a web site outside of the berkeley.edu
+domain. For such domains, the group account must:
 
  1.   Apply to the OCF Board of Directors for a permission to host this domain.
- 2.   Pay any and all fees and/or obtain permissions relating to obtaining and maintaining a domain name.
+ 2.   Pay any and all fees and/or obtain permissions relating to obtaining and
+      maintaining a domain name.
 
 #### University policies
 
-Virtual web sites, just like other OCF user accounts, must comply with the relevant UC Berkeley [computer use policy](https://security.berkeley.edu/policy/usepolicy.html) and [DNS policy](https://security.berkeley.edu/policy/dns).
+Virtual web sites, just like other OCF user accounts, must comply with the
+relevant UC Berkeley [computer use
+policy](https://security.berkeley.edu/policy/usepolicy.html) and [DNS
+policy](https://security.berkeley.edu/policy/dns).
 
 In particular,
 
-* **No off-site (third-party) hosting**: Circumventions around off-site hosting, including (but not limited to) proxies, redirects, and substantial inline frames (iframes) of non-berkeley.edu domains are not allowed. OCF does not process or advise off-site hosting requests, which can be [submitted directly to the university](https://offsitehosting.berkeley.edu/) (however, feel free to keep us informed if you have an existing OCF account).
+* **No off-site (third-party) hosting**: Circumventions around off-site
+  hosting, including (but not limited to) proxies, redirects, and substantial
+  inline frames (iframes) of non-berkeley.edu domains are not allowed. OCF does
+  not process or advise off-site hosting requests, which can be [submitted
+  directly to the university](https://offsitehosting.berkeley.edu/) (however,
+  feel free to keep us informed if you have an existing OCF account).
 
-  In other words, to comply with university policy, OCF will only provide virtual hosting for websites that are substantially hosted on OCF servers.
+  In other words, to comply with university policy, OCF will only provide
+  virtual hosting for websites that are substantially hosted on OCF servers.
 
 #### Hosting badge
 
-All virtual hosts on the OCF must include an [[OCF banner|doc services/vhost/badges]] on the front page that links to the [[OCF home page|home]]. The banner need not be displayed extremely prominently, but it must be noticeable without undue effort. If the banner is removed or misplaced, the OCF reserves the right to terminate the virtual hosting service. The hosting badge not only attributes the OCF but also distinguishes it from sites hosted by other University departments.
+All virtual hosts on the OCF must include an [[OCF banner|doc
+services/vhost/badges]] on the front page that links to the [[OCF home
+page|home]]. The banner need not be displayed extremely prominently, but it
+must be noticeable without undue effort. If the banner is removed or misplaced,
+the OCF reserves the right to terminate the virtual hosting service. The
+hosting badge not only attributes the OCF but also distinguishes it from sites
+hosted by other University departments.
 
 ## Email Forwarding    {email}
 

--- a/ocfweb/docs/docs/services/vhost/mail.md
+++ b/ocfweb/docs/docs/services/vhost/mail.md
@@ -25,14 +25,14 @@ virtual hosting page|vhost_mail]] to add and remove addresses.
 ## How sending and receiving mail works
 
 In the past, we provided a full mail service, including storing mail on our
-servers. However, we found that few groups actually wanted this. Most people are
-already juggling multiple email addresses, and don't particularly want another
-mailbox to monitor.
+servers. However, we found that few groups actually wanted this. Most people
+are already juggling multiple email addresses, and don't particularly want
+another mailbox to monitor.
 
 Instead, we now provide *mail forwarding* for incoming mail, and *mail sending*
 for outgoing mail. This means that incoming mail will always be forwarded to
-some other address (such as your berkeley.edu address or your personal
-Gmail), but you can always send mail using your `@mygroup.berkeley.edu` address.
+some other address (such as your berkeley.edu address or your personal Gmail),
+but you can always send mail using your `@mygroup.berkeley.edu` address.
 
 This is super convenient: you don't have to manage a separate inbox, but you
 can still compose mail or reply to mail as your fancy group email, even from
@@ -44,7 +44,8 @@ providers and clients offer similar options.
 
 #### How can I use Gmail to send and receive email?
 
-[[We have an entire page about that — click here!|doc services/vhost/mail/gmail]]
+[[We have an entire page about that — click here!|doc
+services/vhost/mail/gmail]]
 
 
 #### How can I use an email client besides Gmail to send and receive email?

--- a/ocfweb/docs/docs/services/vhost/mail/gmail.md
+++ b/ocfweb/docs/docs/services/vhost/mail/gmail.md
@@ -18,7 +18,8 @@ or Berkeley email for these steps.
 2. **Set a password for the email.** From the same page as before, make sure
    you've set a secure password for the email address.
 
-   This is the password you'll use when configuring Gmail to send as your account.
+   This is the password you'll use when configuring Gmail to send as your
+   account.
 
 3. **From Gmail, go to the settings page and start adding a new address.**
 
@@ -43,7 +44,8 @@ or Berkeley email for these steps.
    Use the following settings:
 
      * **SMTP Server:** `smtp.ocf.berkeley.edu`
-     * **Username:** The *full email address*, including `@mygroup.berkeley.edu` at the end.
+     * **Username:** The *full email address*, including
+       `@mygroup.berkeley.edu` at the end.
      * **Password:** The password you chose in step 2.
      * **Port:** 587 (the default)
      * **Secured connection:** Using TLS (the default)

--- a/ocfweb/docs/docs/services/web.md
+++ b/ocfweb/docs/docs/services/web.md
@@ -43,12 +43,13 @@ Both individual hosting and student group hosting are done entirely over HTTPS.
 * Ruby 2.1.5; Rails 4.1.8
 
 Other flavors of the day may work but are not currently supported. We may be
-able to install additional packages on request, but will generally advise
-you to use alternatives instead (such as installing in a virtualenv or inside
-your home directory).
+able to install additional packages on request, but will generally advise you
+to use alternatives instead (such as installing in a virtualenv or inside your
+home directory).
 
 
 ## FAQ
+
 ### My `public_html` directory is missing, how do I fix that?
 
 We automatically create the `public_html` symlink for all new accounts, but
@@ -65,7 +66,9 @@ Here are two easy ways to re-create the symlink:
 #### via the web interface
 
 1. Open the [[web commands interface|commands]] in your web browser.
-2. Select the "makehttp" option. Enter your OCF username and password, and choose "Run command". You should see something like this in the output, assuming you entered your username and password correctly:
+2. Select the "makehttp" option. Enter your OCF username and password, and
+   choose "Run command". You should see something like this in the output,
+   assuming you entered your username and password correctly:
 
         public_html folder has been created successfully.
 
@@ -77,7 +80,8 @@ Here are two easy ways to re-create the symlink:
 
         tsunami$
 
-    At this prompt, type `makehttp`. This command will create your web directory. Here's a sample screen output:
+    At this prompt, type `makehttp`. This command will create your web
+    directory. Here's a sample screen output:
 
         tsunami$ makehttp
         public_html folder has been created successfully.

--- a/ocfweb/docs/docs/services/web/backups.md
+++ b/ocfweb/docs/docs/services/web/backups.md
@@ -9,9 +9,9 @@ find you need a backup history of your own when you need to:
 * Regress to a previous state due to a bug
 * Recover from a security breach
 
-You can make easy-to-restore backups over [[SSH|doc services/shell]] by following
-the examples on this page. You could alternatively use SFTP, but this wouldn't
-allow you to back up a database.
+You can make easy-to-restore backups over [[SSH|doc services/shell]] by
+following the examples on this page. You could alternatively use SFTP, but this
+wouldn't allow you to back up a database.
 
 
 ## Backing up a web directory
@@ -27,9 +27,8 @@ can save your website `~/public_html` there with the following command:
 
     tar czhf ~/backups/backup.tar.gz ~/public_html
 
-To restore the backup, you would first remove the contents of
-`~/public_html` (i.e. `rm -r ~/public_html`) and then extract the compressed
-file.
+To restore the backup, you would first remove the contents of `~/public_html`
+(i.e. `rm -r ~/public_html`) and then extract the compressed file.
 
     cd ~/public_html
     tar xzhf ~/backups/backup.tar.gz
@@ -84,12 +83,13 @@ allow you to use MySQL without entering the password by hand.
 If you have an old website you want to archive and remove from public view, you
 can make a backup of it using the above instructions and then delete your
 webiste files and database. When deleting files, be sure to delete the contents
-inside of `public_html` and not just `public_html` itself, which is a mere link.
+inside of `public_html` and not just `public_html` itself, which is a mere
+link.
 
 The easiest way to remove the contents of your database is to log into
-phpMyAdmin at [https://pma.ocf.berkeley.edu](https://pma.ocf.berkeley.edu)
-with your OCF username and MySQL password. There, you can select all tables
-using the check boxes and select `Drop` to delete them all.
+phpMyAdmin at [https://pma.ocf.berkeley.edu](https://pma.ocf.berkeley.edu) with
+your OCF username and MySQL password. There, you can select all tables using
+the check boxes and select `Drop` to delete them all.
 
 If you instead wanted to delete the whole database, you could use the command
 
@@ -114,7 +114,8 @@ while a restore would look like this:
     Enter password:
     johndoe@tsunami:~$ tar xzhf ~/site-backup-7-26-15.tar.gz -C ~/ public_html
 
-If you were using `.my.cnf`, you wouldn't even have to enter your database password.
+If you were using `.my.cnf`, you wouldn't even have to enter your database
+password.
 
 
 ## Security

--- a/ocfweb/docs/docs/services/web/django.md
+++ b/ocfweb/docs/docs/services/web/django.md
@@ -5,76 +5,87 @@ Django is a popular web framework for Python applications.
 
 ## Starting a Django project
 
-The necessary scripts for you to create Django projects are installed on our login server, _ssh.ocf.berkeley.edu_.
+The necessary scripts for you to create Django projects are installed on our
+login server, _ssh.ocf.berkeley.edu_.
 
-1.   First, you will want to create a directory to store all of your Django projects. This directory should not be in your *public_html* directory.
+1.   First, you will want to create a directory to store all of your Django
+     projects. This directory should not be in your *public_html* directory.
 
-        tsunami$ mkdir ~/projects
+         tsunami$ mkdir ~/projects
 
 1.   Go into the directory you just created:
 
-        tsunami$ cd ~/projects
+         tsunami$ cd ~/projects
 
-1.  Create a new Django project. For this example, the project name will be "hatsune". You will want to stick with Python-friendly package and module names, as detailed in [PEP 8](https://www.python.org/dev/peps/pep-0008/#package-and-module-names).
+1.   Create a new Django project. For this example, the project name will be
+     "hatsune". You will want to stick with Python-friendly package and module
+     names, as detailed in [PEP
+     8](https://www.python.org/dev/peps/pep-0008/#package-and-module-names).
 
-        tsunami$ django-admin startproject hatsune
+         tsunami$ django-admin startproject hatsune
 
-1.   Go into the project directory you just created and edit the settings.py file with the necessary information:
+1.   Go into the project directory you just created and edit the settings.py
+     file with the necessary information:
 
-        tsunami$ cd hatsune
-        tsunami$ vim settings.py
+         tsunami$ cd hatsune
+         tsunami$ vim settings.py
 
-1.   Change the permissions of the settings.py file, since it might have sensitive information like your database password!
+1.   Change the permissions of the settings.py file, since it might have
+     sensitive information like your database password!
 
-        tsunami$ chmod go-rwx settings.py
+         tsunami$ chmod go-rwx settings.py
 
 1.   Create an app, edit it, and so on:
 
-        tsunami$ django-admin startapp miku
-        tsunami$ vim miku/views.py
-        ...
-        tsunami$ vim urls.py
+         tsunami$ django-admin startapp miku
+         tsunami$ vim miku/views.py
+         ...
+         tsunami$ vim urls.py
 
 1.    Make a directory in your ~/public_html directory:
 
         tsunami$ mkdir ~/public_html/hatsune
 
-1.    Go into the directory you just created, and create two files: *.htaccess* (note the dot), and *run.fcgi*.
+1.    Go into the directory you just created, and create two files: *.htaccess*
+      (note the dot), and *run.fcgi*.
 
 * .htaccess:
 
-            RewriteEngine On
-            RewriteBase /
-            RewriteCond %{REQUEST_FILENAME} !-f
-            # Change "username" and "hatsune" to your username and whatever directory name you made in public_html, respectively
-            RewriteRule ^(.*)$ /~username/hatsune/run.fcgi/$1 [QSA,L]
+      RewriteEngine On
+      RewriteBase /
+      RewriteCond %{REQUEST_FILENAME} !-f
+      # Change "username" and "hatsune" to your username and whatever directory name you made in public_html, respectively
+      RewriteRule ^(.*)$ /~username/hatsune/run.fcgi/$1 [QSA,L]
 
 * run.fcgi:
 
-            #!/usr/bin/env python
-            import sys, os
+      #!/usr/bin/env python
+      import sys, os
 
-            # Change this path to reflect the real directory where your django-project lives
-            projects_location = "/home/k/ke/kedo/django"
-            project_name = "hatsune"
+      # Change this path to reflect the real directory where your django-project lives
+      projects_location = "/home/k/ke/kedo/django"
+      project_name = "hatsune"
 
-            sys.path.insert(0, projects_location)
-            sys.path.insert(1, os.path.join(projects_location, project_name))
-            os.chdir(projects_location)
+      sys.path.insert(0, projects_location)
+      sys.path.insert(1, os.path.join(projects_location, project_name))
+      os.chdir(projects_location)
 
-            os.environ['DJANGO_SETTINGS_MODULE'] = "%s.settings" % project_name
+      os.environ['DJANGO_SETTINGS_MODULE'] = "%s.settings" % project_name
 
-            from django.core.servers.fastcgi import runfastcgi
-            runfastcgi(method="threaded", daemonize="false")
+      from django.core.servers.fastcgi import runfastcgi
+      runfastcgi(method="threaded", daemonize="false")
 
 1.   Make the *run.fcgi* file you just created executable:
 
-        tsunami$ chmod a+x run.fcgi
+         tsunami$ chmod a+x run.fcgi
 
-1. Double check that your *settings.py* file is *not* readable by any other users, and try not to leave DEBUG set to True in your settings.py. Also note that paths are very finicky for Django (and Python) projects, and incorrect paths will likely be the source of any problems.
+1. Double check that your *settings.py* file is *not* readable by any other
+   users, and try not to leave DEBUG set to True in your settings.py. Also note
+   that paths are very finicky for Django (and Python) projects, and incorrect
+   paths will likely be the source of any problems.
 
 1. Once your app has started running, changes you make to the Python code or
    templates won't take effect for a few hours. To apply changes immediately,
    you can touch the run.fcgi file with the command:
 
-        tsunami$ touch run.fcgi
+       tsunami$ touch run.fcgi

--- a/ocfweb/docs/docs/services/web/flask.md
+++ b/ocfweb/docs/docs/services/web/flask.md
@@ -1,6 +1,7 @@
 [[!meta title="Flask"]]
 
-Flask is a popular microframework for Python web development. Using it on the OCF servers requires only just a little extra configuration.
+Flask is a popular microframework for Python web development. Using it on the
+OCF servers requires only just a little extra configuration.
 
 
 ## Starting a Flask project
@@ -9,7 +10,8 @@ Flask is a popular microframework for Python web development. Using it on the OC
 
           $ mkdir ~/public_html/flasky
 
-1.    Go into the directory you just created, and create two files: *.htaccess* (note the dot), and *run.fcgi*.
+1.    Go into the directory you just created, and create two files: *.htaccess*
+      (note the dot), and *run.fcgi*.
 
 * .htaccess:
 
@@ -28,7 +30,8 @@ Flask is a popular microframework for Python web development. Using it on the OC
       if __name__ == '__main__':
           WSGIServer(app).run()
 
-1.    Either add your application as a module in this folder or a subdirectory that will be treated as a python package:
+1.    Either add your application as a module in this folder or a subdirectory
+      that will be treated as a python package:
 
 * Case 1:
 

--- a/ocfweb/docs/docs/services/web/php.md
+++ b/ocfweb/docs/docs/services/web/php.md
@@ -19,12 +19,12 @@ require larger than normal file uploads), you can customize the PHP settings
 used by creating [a `.user.ini` file][.user.ini] inside your web root.
 
 In order to maintain compatibility with the OCF's PHP settings, we highly
-recommend *not* copying an entire `php.ini`* or `.user.ini` file from the web or
-from another server. Instead, we advise you to create an empty `.user.ini` and
-add only the settings you wish to change.
+recommend *not* copying an entire `php.ini`* or `.user.ini` file from the web
+or from another server. Instead, we advise you to create an empty `.user.ini`
+and add only the settings you wish to change.
 
-Note that `.user.ini` filename should be used, as our webserver will not look for
-(per-user) `php.ini` files.
+Note that `.user.ini` filename should be used, as our webserver will not look
+for (per-user) `php.ini` files.
 
 ### Example `.user.ini` file
 

--- a/ocfweb/docs/docs/services/web/rails.md
+++ b/ocfweb/docs/docs/services/web/rails.md
@@ -5,8 +5,9 @@ Ruby on Rails is a popular web framework for Ruby applications.
 
 ## Creating a New Application
 
-To create a new Rails application, use the `rails` command-line interface. For example,
-to create an application called `foo` in your home directory, run the command:
+To create a new Rails application, use the `rails` command-line interface. For
+example, to create an application called `foo` in your home directory, run the
+command:
 
     rails new foo
 
@@ -14,8 +15,8 @@ This may take some time.
 
 ## Hosting Your Application
 
-OCF allows hosting of Rails applications via FastCGI. This requires you to install the
-`fcgi` gem and create a FastCGI wrapper script.
+OCF allows hosting of Rails applications via FastCGI. This requires you to
+install the `fcgi` gem and create a FastCGI wrapper script.
 
 ### Install `fcgi` gem
 

--- a/ocfweb/docs/docs/services/web/wordpress.md
+++ b/ocfweb/docs/docs/services/web/wordpress.md
@@ -12,8 +12,8 @@ during staff hours|staff-hours]] for in-person assistance.
 
 ## Installing WordPress
 
-The easiest way to set up WordPress is via [[SSH|doc services/shell]]. Some simple
-instructions:
+The easiest way to set up WordPress is via [[SSH|doc services/shell]]. Some
+simple instructions:
 
 1. Go to our [web-based SSH client](https://ssh.ocf.berkeley.edu/) and sign in
    with your username and password.
@@ -54,14 +54,15 @@ password you created and start configuring your site.
 ## Migrating from WordPress.com to OCF
 
 If you already have a site hosted at WordPress.com and you'd like to move it to
-OCF web hosting, for example, to become eligible for [[virtual
-hosting|doc services/vhost]], you can move most of your website's functionality and
-content to the OCF's servers. Generally, the process is simple and sites
-migrated from WordPress.com hosting to the OCF function quite well, apart from
-possible minor differences in the appearance of themes. However, if you're looking
-to create your website from scratch, in most cases it will be much easier to just
-install WordPress on your OCF account and start editing it here, rather than creating it locally
-or on another provider like WordPress.com and transferring things over.
+OCF web hosting, for example, to become eligible for [[virtual hosting|doc
+services/vhost]], you can move most of your website's functionality and content
+to the OCF's servers. Generally, the process is simple and sites migrated from
+WordPress.com hosting to the OCF function quite well, apart from possible minor
+differences in the appearance of themes. However, if you're looking to create
+your website from scratch, in most cases it will be much easier to just install
+WordPress on your OCF account and start editing it here, rather than creating
+it locally or on another provider like WordPress.com and transferring things
+over.
 
 If you have an old WordPress installation lying around -- if you are replacing
 an old student group website, for example -- you should archive it before
@@ -75,9 +76,9 @@ The basic steps to migration are as follows:
 2. Use the web admin dashboard to install all the themes and plugins you were
    using at WordPress.com
 
-3. Log into your WordPress.com dashboard and go to `Settings > Export` to download
-   a zipped XML file with all your site's posts and content. Note that this export
-   usually will not include all of your media content.
+3. Log into your WordPress.com dashboard and go to `Settings > Export` to
+   download a zipped XML file with all your site's posts and content. Note that
+   this export usually will not include all of your media content.
 
 4. Unzip this file and change the file extension of all .xml files to .wxr
 
@@ -133,7 +134,8 @@ hours|staff-hours]] instead.
    cd ~/public_html
    ```
 
-3. Figure out your username using the command `wp user list`. You should see output like the below:
+3. Figure out your username using the command `wp user list`. You should see
+   output like the below:
 
    ```shell
    $ wp user list

--- a/ocfweb/docs/docs/services/webapps.md
+++ b/ocfweb/docs/docs/services/webapps.md
@@ -23,9 +23,9 @@ virtual host request form.
 
 ## Requesting app hosting
 
-To request app hosting, you need to first [[create an OCF group
-account|doc membership]]. Once you have an account, email `hostmaster@ocf` with at
-least the following information:
+To request app hosting, you need to first [[create an OCF group account|doc
+membership]]. Once you have an account, email `hostmaster@ocf` with at least
+the following information:
 
 * Group's account name
 * Group's current website, if any (even if not hosted by OCF)
@@ -51,7 +51,8 @@ We provide a separate server (currently named `werewolves`), for hosting
 applications. **You should connect to this server**, not to the public login
 server.
 
-You connect to this server via SSH using your normal OCF account name and password.
+You connect to this server via SSH using your normal OCF account name and
+password.
 
 * **Host:** apphost.ocf.berkeley.edu
 * **Port:** 22
@@ -78,8 +79,8 @@ We may restart the application server as part of regular maintenance, and
 you'll want your app to start again when we do. You'll also want your app to
 automatically restart if it crashes.
 
-We highly recommend to use systemd to supervise your app. Our recommended
-setup is:
+We highly recommend to use systemd to supervise your app. Our recommended setup
+is:
 
 1. Create a directory for your app `~/myapp`.
 
@@ -98,12 +99,12 @@ setup is:
    the `run` script should end with an `exec` line so that signals are sent to
    the server (and not to the shell that started it).
 
-   Once you've written the script, make it executable
-   (`chmod +x ~/myapp/run`). Test it by executing it in your terminal
-   before moving on; it will be easier to debug problems.
+   Once you've written the script, make it executable (`chmod +x ~/myapp/run`).
+   Test it by executing it in your terminal before moving on; it will be easier
+   to debug problems.
 
-3. Write a systemd service file so your app will be supervised on startup.
-   Save the following to the file `~/.config/systemd/user/myapp.service`:
+3. Write a systemd service file so your app will be supervised on startup. Save
+   the following to the file `~/.config/systemd/user/myapp.service`:
 
        [Unit]
        Description={YOUR GROUP NAME} Webapp
@@ -141,9 +142,9 @@ for more options.
 ## Frequently asked questions
 ### Can you install a package on the app server?
 
-Probably. [[Send us an email|doc contact]], and be sure to provide the name of the
-[Debian package][dpkg] you want us to install. Keep in mind we'll probably be
-installing the stable version of the package, so it might be old.
+Probably. [[Send us an email|doc contact]], and be sure to provide the name of
+the [Debian package][dpkg] you want us to install. Keep in mind we'll probably
+be installing the stable version of the package, so it might be old.
 
 You might prefer to install the package locally. See below.
 
@@ -171,7 +172,7 @@ for you (you could install one in your home directory if you *really* want to).
 ### I'm running my app on port 3000 but I can't access it.
 
 The app server is behind a firewall; you won't be able to access most ports
-from outside of the OCF. You could come work from [[the lab|doc services/lab]], or
-forward the port over SSH from elsewhere.
+from outside of the OCF. You could come work from [[the lab|doc services/lab]],
+or forward the port over SSH from elsewhere.
 
 [dpkg]: https://www.debian.org/distrib/packages#search_packages

--- a/ocfweb/docs/docs/services/webapps/nodejs.md
+++ b/ocfweb/docs/docs/services/webapps/nodejs.md
@@ -31,8 +31,8 @@ install and manage dependencies and versions.
        nvm install 0.10
        nvm alias default 0.10
 
-4. Copy your code to `~/myapp/src` or similar, and install any
-   dependencies using `npm`.
+4. Copy your code to `~/myapp/src` or similar, and install any dependencies
+   using `npm`.
 
 ## Preparing your app to be supervised
 
@@ -63,7 +63,7 @@ supervise your app (so that it starts and restarts automatically).
 ## Suggestions/improvements?
 
 If you have a better way to host Node.js-based apps on the app server (or a
-suggestion for how we could improve this documentation),
-[[send us an email|doc contact]]!
+suggestion for how we could improve this documentation), [[send us an email|doc
+contact]]!
 
 [nvm-github]: https://github.com/creationix/nvm

--- a/ocfweb/docs/docs/services/webapps/python.md
+++ b/ocfweb/docs/docs/services/webapps/python.md
@@ -26,8 +26,8 @@ easily install and manage dependencies and versions.
    You should do this step every time before running your app or managing
    installed packages.
 
-4. Copy your code to `~/myapp/src` or similar, and install any
-   dependencies using `pip`.
+4. Copy your code to `~/myapp/src` or similar, and install any dependencies
+   using `pip`.
 
 ## Installing gunicorn
 
@@ -76,7 +76,7 @@ and then running `systemctl --user daemon-reload`. After that, you can use
 ## Suggestions/improvements?
 
 If you have a better way to host Python-based apps on the app server (or a
-suggestion for how we could improve this documentation),
-[[send us an email|doc contact]]!
+suggestion for how we could improve this documentation), [[send us an email|doc
+contact]]!
 
 [lol-syntax]: https://stackoverflow.com/a/25611194

--- a/ocfweb/docs/docs/services/webapps/rails.md
+++ b/ocfweb/docs/docs/services/webapps/rails.md
@@ -39,18 +39,18 @@ install and manage dependencies and versions.
        echo "export PATH=~/.rvm/gems/ruby-2.1.2/bin:\$PATH" >> ~/.bash_profile
        export PATH=~/.rvm/gems/ruby-2.1.2/bin:$PATH
 
-4. Copy your code to `~/myapp/src` or similar, and install any
-   dependencies using `bundle install` (or `gem` manually, if you aren't using
-   bundler).
+4. Copy your code to `~/myapp/src` or similar, and install any dependencies
+   using `bundle install` (or `gem` manually, if you aren't using bundler).
 
    This will download and build many gems. We've tried to install all the
    headers (dev packages) needed for building common gems, but if building a
-   gem fails due to a missing header, just [[send us an email|doc contact]] so we
-   can add it.
+   gem fails due to a missing header, just [[send us an email|doc contact]] so
+   we can add it.
 
 ## Installing unicorn
 
-We recommend using unicorn to serve your application. After setting up rvm, add a line to you app's Gemfile:
+We recommend using unicorn to serve your application. After setting up rvm, add
+a line to you app's Gemfile:
 
     'unicorn'
 
@@ -67,8 +67,7 @@ Create a file at `~/myapp/run` with content like:
           exec ~/.rvm/gems/ruby-2.1.2/bin/unicorn_rails \
           -l /srv/apps/$(whoami)/$(whoami).sock
 
-Replace `~/myapp/src` with the path to your app, then make `run`
-executable:
+Replace `~/myapp/src` with the path to your app, then make `run` executable:
 
     chmod +x ~/myapp/run
 
@@ -92,7 +91,7 @@ supervise your app (so that it starts and restarts automatically).
 ## Suggestions/improvements?
 
 If you have a better way to host Rails-based apps on the app server (or a
-suggestion for how we could improve this documentation),
-[[send us an email|doc contact]]!
+suggestion for how we could improve this documentation), [[send us an email|doc
+contact]]!
 
 [rvm]: https://rvm.io/

--- a/ocfweb/docs/docs/staff/backend.md
+++ b/ocfweb/docs/docs/staff/backend.md
@@ -1,3 +1,4 @@
 [[!meta title="Infrastructure"]]
 
-Many parts of the OCF are not exposed to users. This section will shed light on some of those details.
+Many parts of the OCF are not exposed to users. This section will shed light on
+some of those details.

--- a/ocfweb/docs/docs/staff/backend/backups.md
+++ b/ocfweb/docs/docs/staff/backend/backups.md
@@ -25,9 +25,9 @@ since they contain all of the OCF's important data.  The backups are already
 encrypted, but it doesn't hurt to add a little extra security to that.
 
 We also use Google Nearline on an ad-hoc basis (i.e. we have scripts to make
-the backup, but they only upload and don't remove the old backups). They're
-not yet executed automatically and require some human care to ensure things
-work properly.
+the backup, but they only upload and don't remove the old backups). They're not
+yet executed automatically and require some human care to ensure things work
+properly.
 
 
 ## Backup Contents
@@ -50,18 +50,18 @@ monthly backups, but we might adjust this as it takes more space or we get
 larger backup drives.
 
 We use `rsnapshot` to make incremental backups. Typically, each new backup
-takes an additional ~3GiB of space (but this will vary based on how many
-files actually changed). A full backup is about ~1.3TiB of space and growing.
+takes an additional ~3GiB of space (but this will vary based on how many files
+actually changed). A full backup is about ~1.3TiB of space and growing.
 
 (The incremental file backups are only about ~300 MiB, but since mysqldump
-files can't be incrementally backed up, those take a whole ~2 GiB each time,
-so the total backup grows by ~3GiB each time.)
+files can't be incrementally backed up, those take a whole ~2 GiB each time, so
+the total backup grows by ~3GiB each time.)
 
 #### Request Tracker
 
 The RT database is stored in the `ocfrt` database on the MySQL host. It is
-possible to restore RT using just the database; in fact, simply running
-puppet is now sufficient to bring up a fully-functioning RT server.
+possible to restore RT using just the database; in fact, simply running puppet
+is now sufficient to bring up a fully-functioning RT server.
 
 ## Ideas for backup improvements
 
@@ -76,8 +76,8 @@ Some general ideas for improving backups:
 
 2. **Done.** Make the backup on hal automatically clone the backup on pandemic
    periodically. Should find a way to make it happen only when no backups are
-   going on (which might be hard, since copying all the files takes a long
-   time -- about 7.25 hours).
+   going on (which might be hard, since copying all the files takes a long time
+   -- about 7.25 hours).
 
    Currently there is a script `hal:/opt/copy-backups.sh`, but we need some
    more complicated setup than just putting it in cron (it requires SSHing to

--- a/ocfweb/docs/docs/staff/backend/firewall.md
+++ b/ocfweb/docs/docs/staff/backend/firewall.md
@@ -19,8 +19,8 @@ reload. However, changes will revert on restart unless they are saved to the
 startup config (see below):
 
 * To show a list of available commands, append `?` after the command: For
-  example, use `?` by itself to show all possible starts to commands or `show ?`
-  to list just the sub-commands under `show`.
+  example, use `?` by itself to show all possible starts to commands or `show
+  ?` to list just the sub-commands under `show`.
 
 * Show the running config: `show running-config`
 
@@ -54,8 +54,8 @@ startup config (see below):
 
   (always do this after testing your changes, or they'll revert upon restart!)
 
-(These commands are similar to the commands used for the
-[[switch|doc staff/backend/switch]].)
+(These commands are similar to the commands used for the [[switch|doc
+staff/backend/switch]].)
 
 
 ### Option 2: Using the Java GUI

--- a/ocfweb/docs/docs/staff/backend/git.md
+++ b/ocfweb/docs/docs/staff/backend/git.md
@@ -1,23 +1,39 @@
 [[!meta title="Git"]]
 
 
-Git is a distributed revision control system used by the OCF. Other version control systems include Mercurial (also distributed) and Subversion (not distributed).
+Git is a distributed revision control system used by the OCF. Other version
+control systems include Mercurial (also distributed) and Subversion (not
+distributed).
 
 ## Workflow
 
-Although Git is a great tool for large-scale distributed development, for us a Subversion-like workflow with a "central repository" (where you clone/fetch from and push to) and linear history makes more sense. The instructions below assume that development is happening in a single branch.
+Although Git is a great tool for large-scale distributed development, for us a
+Subversion-like workflow with a "central repository" (where you clone/fetch
+from and push to) and linear history makes more sense. The instructions below
+assume that development is happening in a single branch.
 
-**Only commit your own, original work**.  You may commit another staff member's work if you have permission and change the author appropriately (e.g., `--author="Guest User <guser@ocf.berkeley.edu>"`). When committing, `git config user.name` should be your name and `git config user.email` should be your OCF email address -- this should be taken care of by [[LDAP|doc staff/backend/ldap]] and `/etc/mailname` on OCF machines.
+**Only commit your own, original work**.  You may commit another staff member's
+work if you have permission and change the author appropriately (e.g.,
+`--author="Guest User <guser@ocf.berkeley.edu>"`). When committing, `git config
+user.name` should be your name and `git config user.email` should be your OCF
+email address -- this should be taken care of by [[LDAP|doc
+staff/backend/ldap]] and `/etc/mailname` on OCF machines.
 
 ### To "update"
 
-Get the latest commits from the central repository and update your working tree.
+Get the latest commits from the central repository and update your working
+tree.
 
     git pull --rebase
 
-This will `git fetch` (update your local copy of the remote repository) and `git rebase` (rewrite current branch in terms of tracked branch). The rebase prevents unnecessary merge commits by moving your local commits on top of the latest remote commit (`FETCH_HEAD`). This is a good thing if you have any local commits which have not yet been pushed to the remote repository.
+This will `git fetch` (update your local copy of the remote repository) and
+`git rebase` (rewrite current branch in terms of tracked branch). The rebase
+prevents unnecessary merge commits by moving your local commits on top of the
+latest remote commit (`FETCH_HEAD`). This is a good thing if you have any local
+commits which have not yet been pushed to the remote repository.
 
-If you have "dirty" uncommitted changes, you'll need to commit them or stash them before rebasing (`git stash`).
+If you have "dirty" uncommitted changes, you'll need to commit them or stash
+them before rebasing (`git stash`).
 
 ### To "upload"
 
@@ -29,20 +45,25 @@ Make commits and push them to the central repository.
     git rebase -i # clean up the history (reword or squash commits)
     git push      # push current branch to tracked branch in remote repository
 
-Use `git add -p` to inspect individual changes before adding each one to the index, and `git commit -v` to show a diff of your commit when you are prompted for a commit message.
+Use `git add -p` to inspect individual changes before adding each one to the
+index, and `git commit -v` to show a diff of your commit when you are prompted
+for a commit message.
 
-If commits have been made on the remote repository in the meantime, you'll need to "update" first (see above).
+If commits have been made on the remote repository in the meantime, you'll need
+to "update" first (see above).
 
 ### To "import"
 
-Pull someone else's changes into the central repository, for example from a branch in a staff member's repository (`REMOTE`).
+Pull someone else's changes into the central repository, for example from a
+branch in a staff member's repository (`REMOTE`).
 
     git fetch REMOTE                             # update local copy of remote
     git log --graph --decorate FETCH_HEAD ^HEAD^ # list remote commits on top of current branch
     git diff FETCH_HEAD                          # compare current branch with remote branch
     git merge --ff-only FETCH_HEAD               # merge in if can linearly fast-forward
 
-If you can't fast-forward merge, "update" the remote repository first (see above).
+If you can't fast-forward merge, "update" the remote repository first (see
+above).
 
 If you want a merge commit, you can `git merge --no-ff` instead.
 
@@ -83,21 +104,27 @@ Advanced:
   * line of changes in a repository, default branch is `master`
 * fast-forward
   * advance branch forward in a linear sequence
-  * this is usually what we want: the new commit builds directly on the previous commit
+  * this is usually what we want: the new commit builds directly on the
+    previous commit
 * hooks
   * optional scripts that can be executed during git operations
-  * for example, validate syntax before accepting a commit or deploy code to a server
+  * for example, validate syntax before accepting a commit or deploy code to a
+    server
 * index (aka staging area)
   * files that are ready to be stored in your next commit
 * references (aka refs)
   * SHA-1 hashes that identify commits
-  * `HEAD` points to the latest commit ref in the current branch (`HEAD^` to the one before it)
+  * `HEAD` points to the latest commit ref in the current branch (`HEAD^` to
+    the one before it)
 * remote
-  * upstream repository that you can `git fetch` from or `git push` to, default is `origin`
-  * local branches can "track" remote branches (e.g., `master` tracking `origin/master`)
+  * upstream repository that you can `git fetch` from or `git push` to, default
+    is `origin`
+  * local branches can "track" remote branches (e.g., `master` tracking
+    `origin/master`)
 * working tree (aka workspace or working directory)
   * directory that checked out files reside
-  * this includes the current branch and any "dirty" uncommitted changes (staged or not)
+  * this includes the current branch and any "dirty" uncommitted changes
+    (staged or not)
 
 ## Recommended reading
 

--- a/ocfweb/docs/docs/staff/backend/jenkins.md
+++ b/ocfweb/docs/docs/staff/backend/jenkins.md
@@ -62,6 +62,7 @@ safer.
 
 
 ## Jenkins for GitHub projects
+
 ### On the master branch
 
 To test GitHub projects when you push to master:
@@ -111,7 +112,8 @@ testing pull requests. For example, `puppet-test-pr`.
    "Use github hooks for build triggering".
 
 6. Under "GitHub Pull Request Builder", delete all lines under "Admin List" (if
-   there are any). Add "ocf" as the only line to the "List of organizations" box.
+   there are any). Add "ocf" as the only line to the "List of organizations"
+   box.
 
 7. On GitHub, under "Settings" and "Webhooks & services", add a new webhook
    with payload URL `https://jenkins.ocf.berkeley.edu/ghprbhook/`, content type

--- a/ocfweb/docs/docs/staff/backend/kerberos.md
+++ b/ocfweb/docs/docs/staff/backend/kerberos.md
@@ -53,8 +53,8 @@ mean:
 - **KDC** (**K**ey **D**istribution **C**enter): The central server that issues
   tickets for Kerberos communication and stores all user's keys. If the KDC is
   compromised, you are going to have a very bad time and [will not go to space
-  today][xkcd-space]. Our current KDC is firestorm, but that could change in the
-  future, as servers are moved around or rebuilt.
+  today][xkcd-space]. Our current KDC is firestorm, but that could change in
+  the future, as servers are moved around or rebuilt.
 
 - **Realm**: A kerberos domain, usually identified with the domain name in all
   caps (e.g. `OCF.BERKELEY.EDU`). Two hosts are in the same realm if they share
@@ -126,8 +126,8 @@ All conveniently prefixed with the letter `k`.
 
 - `kadmin`: Administration utility for Kerberos to make changes to the Kerberos
   database, either locally (with `-l`), or remotely by connecting to the KDC.
-  Can retrieve information about principals, modify principal attributes, change
-  principal passwords, show privileges allowed, etc.
+  Can retrieve information about principals, modify principal attributes,
+  change principal passwords, show privileges allowed, etc.
 
 - `kdestroy`: Remove a principal or ticket file. This is essentially the
   opposite of `kinit`, so it invalidates tickets you have, logging you out from
@@ -184,9 +184,9 @@ depth than the rather cursory overview found here:
    KDC).
 
 3. The client gets the encrypted TGT and decrypts it with the user's entered
-   password. Note the user's password was never directly sent across the network
-   at any stage in the process. Then the TGT is stored in the cache on the
-   client machine until it expires, when it is requested again if needed.
+   password. Note the user's password was never directly sent across the
+   network at any stage in the process. Then the TGT is stored in the cache on
+   the client machine until it expires, when it is requested again if needed.
 
 4. The user can then use this TGT to make requests for service tickets from the
    KDC.
@@ -211,9 +211,9 @@ or a HTTP Kerberos login, then they make more requests to the KDC:
    contacting a service and authenticating until the service ticket expires.
 
 2. The client can then use this service ticket to send with requests to
-   Kerberos-enabled services, like SSH, as user authentication. The service will
-   verify the ticket with the KDC when used, to make sure it is valid for the
-   user issuing the request.
+   Kerberos-enabled services, like SSH, as user authentication. The service
+   will verify the ticket with the KDC when used, to make sure it is valid for
+   the user issuing the request.
 
 [eli5]: http://www.roguelynn.com/words/explain-like-im-5-kerberos/
 [kdc]: https://github.com/ocf/puppet/blob/master/modules/ocf_kerberos/files/kdc.conf#L13

--- a/ocfweb/docs/docs/staff/backend/mail.md
+++ b/ocfweb/docs/docs/staff/backend/mail.md
@@ -1,16 +1,17 @@
 [[!meta title="Mail"]]
 
-**anthrax** is our mail server. It is used for sending and receiving all
-OCF mail, excluding staff use of Google Apps. Mail sent by users, websites,
-virtual hosts, or basically anything else goes through here.
+**anthrax** is our mail server. It is used for sending and receiving all OCF
+mail, excluding staff use of Google Apps. Mail sent by users, websites, virtual
+hosts, or basically anything else goes through here.
 
-Received mail to @ocf.berkeley.edu is looked up via LDAP (or the aliases
-table) and forwarded or rejected; nothing is stored.
+Received mail to @ocf.berkeley.edu is looked up via LDAP (or the aliases table)
+and forwarded or rejected; nothing is stored.
 
 Received virtual host mail is looked up in a MySQL table and forwarded to the
 correct place. Outgoing virtual host mail is also via anthrax, which uses SMTP
 authentication (passwords checked against `crypt(3)`'d passwords in a MySQL
-table). [[There's a whole page with more details about vhost mail.|doc staff/backend/mail/vhost]]
+table). [[There's a whole page with more details about vhost mail.|doc
+staff/backend/mail/vhost]]
 
 Mail originating anywhere inside the OCF relays through anthrax.
 
@@ -19,15 +20,14 @@ Mail originating anywhere inside the OCF relays through anthrax.
 
 We maintain relations with external groups for two reasons.
 
- 1. To monitor our mail server reputation and prevent outgoing mail from
-    being blocked by external service providers.
+ 1. To monitor our mail server reputation and prevent outgoing mail from being
+    blocked by external service providers.
  2. To monitor abuse and disable compromised accounts.
 
 When our IP addresses change, we need to update our registrations.
 
-We have
-[feedback loops](https://en.wikipedia.org/wiki/Feedback_loop_%28email%29)
-with
+We have [feedback
+loops](https://en.wikipedia.org/wiki/Feedback_loop_%28email%29) with
 
  - AOL (out-of-date)
  - Comcast (out-of-date)

--- a/ocfweb/docs/docs/staff/backend/mail/vhost.md
+++ b/ocfweb/docs/docs/staff/backend/mail/vhost.md
@@ -1,8 +1,8 @@
 [[!meta title="Virtual hosted mail"]]
 
 **Note: This page is designed for OCF staffers and is a technical description
-of the service. For information or help using it, see
-[[our page about it|doc services/vhost/mail]].**
+of the service. For information or help using it, see [[our page about it|doc
+services/vhost/mail]].**
 
 Virtual hosting mail allows groups to receive mail at `@group.b.e` addresses,
 and send from those same addresses. It complements our web hosting nicely.
@@ -23,8 +23,8 @@ and send from those same addresses. It complements our web hosting nicely.
 
 ## Technical implementation
 
-There is a database on our MySQL host for storing email vhost information.
-It has one table, `addresses`, with columns for the incoming address, password,
+There is a database on our MySQL host for storing email vhost information. It
+has one table, `addresses`, with columns for the incoming address, password,
 and forwarding addresses (among others).
 
 It has one view, `domains`, which is generated from the `addresses` table. This

--- a/ocfweb/docs/docs/staff/backend/munin.md
+++ b/ocfweb/docs/docs/staff/backend/munin.md
@@ -13,8 +13,8 @@ Additionally, we don't receive email alerts for staff VMs.
 
 Munin sends mail to root whenever certain stats run out of bounds for a
 machine, e.g. if disk usage goes above 92%. Some plugins have configurable
-warning and critical levels for each field, which are usually set in
-the node config like so:
+warning and critical levels for each field, which are usually set in the node
+config like so:
 
 ```text
 [pluginname]

--- a/ocfweb/docs/docs/staff/backend/puppet.md
+++ b/ocfweb/docs/docs/staff/backend/puppet.md
@@ -1,4 +1,6 @@
 [[!meta title="Puppet"]]
 
 
-The puppetmaster is [[lightning|doc staff/backend/servers]]. Instructions on making, testing, and deploying changes to Puppet are located at the [Git repository](https://github.com/ocf/puppet) on GitHub.
+The puppetmaster is [[lightning|doc staff/backend/servers]]. Instructions on
+making, testing, and deploying changes to Puppet are located at the [Git
+repository](https://github.com/ocf/puppet) on GitHub.

--- a/ocfweb/docs/docs/staff/backend/switch.md
+++ b/ocfweb/docs/docs/staff/backend/switch.md
@@ -37,8 +37,8 @@ admin passwords.
 
 Some handy commands (first run `enable` and enter your password again):
 
-These commands are similar to the commands used for the
-[[firewall|doc staff/backend/firewall]], so have a look there for more details.
+These commands are similar to the commands used for the [[firewall|doc
+staff/backend/firewall]], so have a look there for more details.
 
 * Show the running config: `show running-config`
 
@@ -52,8 +52,8 @@ These commands are similar to the commands used for the
 ## Automatic config diffs
 
 We use [rancid](http://www.shrubbery.net/rancid/) to both back up and send us
-email diffs of the switch's config. This is managed through the
-[`ocf_rancid` puppet module][ocf_rancid].
+email diffs of the switch's config. This is managed through the [`ocf_rancid`
+puppet module][ocf_rancid].
 
 
 [switch]: http://www.cisco.com/c/en/us/support/switches/catalyst-2960s-48ts-l-switch/model.html

--- a/ocfweb/docs/docs/staff/powers.md
+++ b/ocfweb/docs/docs/staff/powers.md
@@ -19,7 +19,8 @@ practice most staff members are Directors and vice versa.
 
 * receive `staff@ocf` mail (including staff discussions and announcements)
 * can process group account requests
-* can access and process [Request Tracker](https://rt.ocf.berkeley.edu/) tickets
+* can access and process [Request Tracker](https://rt.ocf.berkeley.edu/)
+  tickets
 * receive `wheel@ocf` mail (including  discussions with technical jargon)
 * can change print quotas
 * can login to all servers
@@ -43,6 +44,7 @@ This is usually given to staff after a semester of demonstrated interest.
 
 
 ## Technical managers
+
 *group ocfroot*
 
 The most technical and "on-call" staff members are given sudo access (root

--- a/ocfweb/docs/docs/staff/procedures/backporting-packages.md
+++ b/ocfweb/docs/docs/staff/procedures/backporting-packages.md
@@ -37,8 +37,8 @@ we'll cover everything you need to know here.
 ## Step 3: Install dependencies
 
 * Enter the new directory and run `dpkg-checkbuilddeps`, and install any
-  dependencies that are missing. If you'd like to install missing
-  dependencies automatically, you can use `sudo mk-build-deps -ir`.
+  dependencies that are missing. If you'd like to install missing dependencies
+  automatically, you can use `sudo mk-build-deps -ir`.
 
 
 ## Step 4: Make any changes (optional)

--- a/ocfweb/docs/docs/staff/procedures/dmca.md
+++ b/ocfweb/docs/docs/staff/procedures/dmca.md
@@ -1,7 +1,14 @@
 [[!meta title="DMCA"]]
 
-DMCA safe harbor provisions help "Online Service Providers" such as us avoid liability from copyright infringement by our users.
+DMCA safe harbor provisions help "Online Service Providers" such as us avoid
+liability from copyright infringement by our users.
 
-We are required to act upon a valid DMCA takedown notice sent to our designated agent (in the University), as specified on our [[contact|doc contact]] page. A good example of instructions for a DMCA takedown notice is the [GitHub DMCA Takedown article](https://help.github.com/articles/dmca-takedown).
+We are required to act upon a valid DMCA takedown notice sent to our designated
+agent (in the University), as specified on our [[contact|doc contact]] page. A
+good example of instructions for a DMCA takedown notice is the [GitHub DMCA
+Takedown article](https://help.github.com/articles/dmca-takedown).
 
-Refer to [Guidelines for Compliance with the Online Service Provider Provisions of the Digital Millennium Copyright Act](http://policy.ucop.edu/doc/7000472/DMCA), a 6-page document by the University of California.
+Refer to [Guidelines for Compliance with the Online Service Provider Provisions
+of the Digital Millennium Copyright
+Act](http://policy.ucop.edu/doc/7000472/DMCA), a 6-page document by the
+University of California.

--- a/ocfweb/docs/docs/staff/procedures/new-host.md
+++ b/ocfweb/docs/docs/staff/procedures/new-host.md
@@ -16,6 +16,7 @@ reverse DNS record.
 
 
 ## Step 2. Create the host, run Debian installer
+
 ### Virtual hosts
 
 We have a handy script, `makevm`, that:
@@ -46,6 +47,7 @@ tty.
 
 
 ## Step 3. Log in and run Puppet
+
 ### Virtual hosts
 
 1. Log in as `root:r00tme`

--- a/ocfweb/docs/docs/staff/procedures/printing.md
+++ b/ocfweb/docs/docs/staff/procedures/printing.md
@@ -53,11 +53,11 @@ them left over after replacing the kit.
 The most complicated part of the kit replacement is actually resetting the
 maintenance kit warning on the printer after it is all installed. To reset the
 warning, turn off the printer using the power switch on the lower right. Then,
-turn on the printer and hold down the `OK` button while the printer is starting.
-Once the printer stops loading any further, release the `OK` button and a
-startup menu should appear. In this menu, select `NEW MAINTENANCE KIT` and press
-the `OK` button and the printer should proceed to start normally with the
-warning reset.
+turn on the printer and hold down the `OK` button while the printer is
+starting. Once the printer stops loading any further, release the `OK` button
+and a startup menu should appear. In this menu, select `NEW MAINTENANCE KIT`
+and press the `OK` button and the printer should proceed to start normally with
+the warning reset.
 
 Our printers use [CB388A maintenance kits][maintkit].
 

--- a/ocfweb/docs/docs/staff/procedures/setting-up-mdraid.md
+++ b/ocfweb/docs/docs/staff/procedures/setting-up-mdraid.md
@@ -55,7 +55,8 @@ because they might need some adjustment.
        $ -PDMakeGood -PhysDrv[252:0,252:1,252:2,252:3] -force -a0
        $ -AdpSetProp EnableJBOD 1 -aALL
        $ -PDMakeJBOD -PhysDrv[252:0,252:1,252:2,252:3] -a0
-*note: I got an error on jaws on the `PDMakeJBOD`, but it worked anyway*
+
+   *note: I got an error on jaws on the `PDMakeJBOD`, but it worked anyway*
 
 3. Reboot into finnix and figure out which drives you want in the RAID.
 
@@ -135,4 +136,5 @@ because they might need some adjustment.
     need to try all of them in your new array until it works, sorry.
 
 14. Undo everything from step 8 on `pestilence`.
+
 15. You're done!

--- a/ocfweb/docs/docs/staff/procedures/ssl.md
+++ b/ocfweb/docs/docs/staff/procedures/ssl.md
@@ -1,49 +1,75 @@
 [[!meta title="SSL certificates"]]
 
-We are able to obtain signed certificates at no charge through the campus [InCommon-Comodo certificate service](https://wikihub.berkeley.edu/display/calnet/CalNet+InCommon-Comodo+Certificate+Service).
+We are able to obtain signed certificates at no charge through the campus
+[InCommon-Comodo certificate
+service](https://wikihub.berkeley.edu/display/calnet/CalNet+InCommon-Comodo+Certificate+Service).
 
-The primary Common Name for a certificate should always be the **server hostname**, with service CNAMEs specified as Subject Alternative Names. A certificate for Request Tracker should have the primary CN `typhoon.ocf.berkeley.edu`, with `rt.ocf.berkeley.edu` as a SAN.
+The primary Common Name for a certificate should always be the **server
+hostname**, with service CNAMEs specified as Subject Alternative Names. A
+certificate for Request Tracker should have the primary CN
+`typhoon.ocf.berkeley.edu`, with `rt.ocf.berkeley.edu` as a SAN.
 
-This allows us to easily distinguish between certificates in cases where a service may be hosted by multiple hostnames, or where the hostname changes, without sharing private keys.
+This allows us to easily distinguish between certificates in cases where a
+service may be hosted by multiple hostnames, or where the hostname changes,
+without sharing private keys.
 
 ## Setting up SSL
+
 ### Generating a key/CSR
-The easiest way to generate a key and CSR is with the `makessl` script provided by `ocf/utils`. Specify the fully-qualified hostname of the server as the only argument. **Do not use service CNAMEs.**
+
+The easiest way to generate a key and CSR is with the `makessl` script provided
+by `ocf/utils`. Specify the fully-qualified hostname of the server as the only
+argument. **Do not use service CNAMEs.**
 
 Example usage:
 
     /opt/share/utils/staff/ssl/makessl supernova.ocf.berkeley.edu
 
-This will create a file `supernova.ocf.berkeley.edu.key` in the same directory, and print a CSR to stdout.
+This will create a file `supernova.ocf.berkeley.edu.key` in the same directory,
+and print a CSR to stdout.
 
 ### Requesting a Certificate
-1. Go to the [InCommon Certificate Manager](https://cert-manager.com/customer/incommon) (or have the current Departmental Certificate Administrator go there).
+
+1. Go to the [InCommon Certificate
+   Manager](https://cert-manager.com/customer/incommon) (or have the current
+   Departmental Certificate Administrator go there).
 
 2. Click "Add" to request a new certificate.
 
-3. Select the type of certificate (either "InCommon SSL" or "InCommon Multi-Domain SSL" if you need SANs), paste the CSR, and hit OK.
+3. Select the type of certificate (either "InCommon SSL" or "InCommon
+   Multi-Domain SSL" if you need SANs), paste the CSR, and hit OK.
 
-5. Approve the certificate and wait for it to be issued. Download "X509 Certificate Only" and place it in a file named `${fqdn}.crt` in the same directory as the key.
+5. Approve the certificate and wait for it to be issued. Download "X509
+   Certificate Only" and place it in a file named `${fqdn}.crt` in the same
+   directory as the key.
 
 ### Installing key/certificate with Puppet
-You should install the key and certificate via Puppet. On lightning, create the directory `/opt/puppet/shares/private/$fqdn/ssl` and place the key and cert in it.
 
-Add the `ocf_ssl` module to the server (e.g. by adding `puppetClass: ocf_ssl` to the server's LDAP entry). This will provide the files:
+You should install the key and certificate via Puppet. On lightning, create the
+directory `/opt/puppet/shares/private/$fqdn/ssl` and place the key and cert in
+it.
+
+Add the `ocf_ssl` module to the server (e.g. by adding `puppetClass: ocf_ssl`
+to the server's LDAP entry). This will provide the files:
 
 * `/etc/ssl/private/${fqdn}.key`
 * `/etc/ssl/private/${fqdn}.crt`
 * `/etc/ssl/private/${fqdn}.bundle`
 
-The bundle file is automatically generated from the certificate you provided, and contains the InCommon intermediate certificate.
+The bundle file is automatically generated from the certificate you provided,
+and contains the InCommon intermediate certificate.
 
 
 ## Verifying certificates
 
-For the host `rt.ocf.berkeley.edu` on port 443 (HTTPS), try connecting using the OpenSSL client.
+For the host `rt.ocf.berkeley.edu` on port 443 (HTTPS), try connecting using
+the OpenSSL client.
 
     openssl s_client -CApath /etc/ssl/certs -connect rt.ocf.berkeley.edu:443
 
-The last line of the SSL session information should have a zero return code. This only verifies the certificate, not that the hostname you entered matches the Common Name or Subject Alternatives Names on the certificate.
+The last line of the SSL session information should have a zero return code.
+This only verifies the certificate, not that the hostname you entered matches
+the Common Name or Subject Alternatives Names on the certificate.
 
 Good:
 
@@ -53,10 +79,12 @@ Bad example 1:
 
     Verify return code: 18 (self signed certificate)
 
-The default self-signed certificate, not the one obtained through InCommon, is probably still being used.
+The default self-signed certificate, not the one obtained through InCommon, is
+probably still being used.
 
 Bad example 2:
 
     Verify return code: 21 (unable to verify the first certificate)
 
-The intermediate CA chain is probably missing (or in the wrong order), so there is no trust path to a root CA.
+The intermediate CA chain is probably missing (or in the wrong order), so there
+is no trust path to a root CA.

--- a/ocfweb/docs/docs/staff/procedures/user-quotas.md
+++ b/ocfweb/docs/docs/staff/procedures/user-quotas.md
@@ -5,8 +5,8 @@ We use the standard Unix quota utilities to set disk quotas.
 
 ### Summary of useful commands
 
-All of these can be executed on `jaws`. Some of them also work on other
-servers which mount NFS.
+All of these can be executed on `jaws`. Some of them also work on other servers
+which mount NFS.
 
 
 #### View your own quota
@@ -46,12 +46,12 @@ instead.
 
 Are you trying to raise disk quotas for every user? Congratulations on finding
 this page! The SM who wrote this section spent a couple of hours trying to
-figure out *how in the hell* our automatic disk quotas were working, despite all
-internet documentation claiming there is no way to set default disk quotas.
+figure out *how in the hell* our automatic disk quotas were working, despite
+all internet documentation claiming there is no way to set default disk quotas.
 
 Indeed, you cannot configure a default quota. You can, however, set quotas for
-non-existent users! We've set quotas for user IDs 1000 through 99999 in order to
-mimic default users.
+non-existent users! We've set quotas for user IDs 1000 through 99999 in order
+to mimic default users.
 
 To raise disk quotas, you can use a command like:
 

--- a/ocfweb/docs/docs/staff/procedures/vhost.md
+++ b/ocfweb/docs/docs/staff/procedures/vhost.md
@@ -1,15 +1,21 @@
 [[!meta title="Virtual hosting (staff)"]]
+
 ## Policy checklist
 
 * Website developed, not a placeholder
 * Website hosted substantially on the OCF
 * Website has required university disclaimer on every page
-* Website has hosted by OCF banner on the front page that is noticeable without undue effort and links to the OCF home page
-* Request is made by a registered and active student organization in CalLink (LEAD Center) or request is sponsored by an [administrative official](http://compliance.berkeley.edu/delegation/principles)
-* Group does not already have a virtual host, or has an exception from the Board of Directors
+* Website has hosted by OCF banner on the front page that is noticeable without
+  undue effort and links to the OCF home page
+* Request is made by a registered and active student organization in CalLink
+  (LEAD Center) or request is sponsored by an [administrative
+  official](http://compliance.berkeley.edu/delegation/principles)
+* Group does not already have a virtual host, or has an exception from the
+  Board of Directors
 
 
 ## Enabling virtual hosting
+
 ### Web
 
 Edit the file `~staff/vhost/vhost.conf`, adding a new line. The format is
@@ -20,14 +26,15 @@ about an additional hour to take effect (for the first hour, it will be
 HTTP-only).
 
 If mail is also requested, skip to the next section. Otherwise, request the
-following DNS record from the
-[University hostmaster](http://www.net.berkeley.edu/hostmaster/):
+following DNS record from the [University
+hostmaster](http://www.net.berkeley.edu/hostmaster/):
 
     hostname.berkeley.edu. IN CNAME death.ocf.berkeley.edu.
 
 Use the domain requested by the group in place of `hostname`. We have a
-[reusable email template](https://templates.ocf.berkeley.edu/#hostmaster-new-domain)
-for making new DNS requests.
+[reusable email
+template](https://templates.ocf.berkeley.edu/#hostmaster-new-domain) for making
+new DNS requests.
 
 ### Mail (if requested)    {mail}
 
@@ -36,28 +43,34 @@ The format is simply:
 
     groupname domainname
 
-This immediately takes effect, allowing the group to [[edit their email config|vhost_mail]]
-(and the mail server will start accepting incoming/outgoing mail), but you
-still need to update the DNS so that they can actually receive mail.
+This immediately takes effect, allowing the group to [[edit their email
+config|vhost_mail]] (and the mail server will start accepting incoming/outgoing
+mail), but you still need to update the DNS so that they can actually receive
+mail.
 
 If the group already has virtual hosting for their website, which is likely the
-case, request from the [University hostmaster](http://www.net.berkeley.edu/hostmaster/)
-that the following DNS record be dropped:
+case, request from the [University
+hostmaster](http://www.net.berkeley.edu/hostmaster/) that the following DNS
+record be dropped:
 
     hostname.Berkeley.EDU. IN CNAME death.OCF.Berkeley.EDU.
 
-Then, whether or not the group has web virtual hosting, request the following DNS records:
+Then, whether or not the group has web virtual hosting, request the following
+DNS records:
 
     hostname.Berkeley.EDU. IN A 169.229.226.23
     hostname.Berkeley.EDU. IN MX 5 anthrax.OCF.Berkeley.EDU.
 
 Use the domain requested by the group in place of `hostname`. We have a
-[reusable email template](https://templates.ocf.berkeley.edu/#hostmaster-add-mail)
-for making DNS mail requests.
+[reusable email
+template](https://templates.ocf.berkeley.edu/#hostmaster-add-mail) for making
+DNS mail requests.
 
 
 ### Application hosting
-The group website should be reasonably developed (can be offsite during review only for this request) before approving it.
+
+The group website should be reasonably developed (can be offsite during review
+only for this request) before approving it.
 
 You will need a `/admin` principle to modify apphosting entries.
 
@@ -81,8 +94,12 @@ Once the cronjob completes, the application will be available at:
 
 VHOST_NAME is the configured name from above.
 
-Once the website is developed and meets policy checklist, request the following DNS record from the [University hostmaster](http://www.net.berkeley.edu/hostmaster/):
+Once the website is developed and meets policy checklist, request the following
+DNS record from the [University
+hostmaster](http://www.net.berkeley.edu/hostmaster/):
 
     hostname.berkeley.edu. IN CNAME werewolves.OCF.Berkeley.EDU
 
-The nginx running on apphosting server will return a `502 Bad Gateway` or actual content if the apphost is configured properly, and a `403 Forbidden` otherwise.
+The nginx running on apphosting server will return a `502 Bad Gateway` or
+actual content if the apphost is configured properly, and a `403 Forbidden`
+otherwise.

--- a/ocfweb/docs/docs/staff/rebuild/rt.md
+++ b/ocfweb/docs/docs/staff/rebuild/rt.md
@@ -12,428 +12,491 @@ Both Apache 2 and Nginx installation are listed below. Pick your poison...
 
 1. Install required packages:
 
-        sudo aptitude install mysql-server
-        sudo aptitude install -t squeeze-backports request-tracker4 rt4-db-mysql
+       sudo aptitude install mysql-server
+       sudo aptitude install -t squeeze-backports request-tracker4 rt4-db-mysql
 
-  **For Apache 2:** Install
+   **For Apache 2:** Install
 
-        sudo install libapache-mod-auth-kerb
-        sudo install -t squeeze-backports rt4-apache
+       sudo install libapache-mod-auth-kerb
+       sudo install -t squeeze-backports rt4-apache
 
-  **For Nginx:** Install
+   **For Nginx:** Install
 
-        sudo install -t squeeze-backports nginx rt4-fcgi
+       sudo install -t squeeze-backports nginx rt4-fcgi
 
-  and enable the RT FastCGI daemon: in `/etc/default/rt4-fcgi`, edit:
+   and enable the RT FastCGI daemon: in `/etc/default/rt4-fcgi`, edit:
 
-        enabled=1
+       enabled=1
 
-  Debian packages an obscenely old version of Nginx in stable, so please don't install that. People will laugh at you.
+   Debian packages an obscenely old version of Nginx in stable, so please don't
+   install that. People will laugh at you.
 
-  Configuration by debconf:
-     - Name: rt.ocf.berkeley.edu
-     - Handle RT_SiteConfig.pm permissions: yes
-     - SQL password: ....
+   Configuration by debconf:
+   - Name: rt.ocf.berkeley.edu
+   - Handle RT_SiteConfig.pm permissions: yes
+   - SQL password: ....
 
-  Install RT::Extension::CommandByMail and RT::Extension::MergeUsers:
+   Install RT::Extension::CommandByMail and RT::Extension::MergeUsers:
 
-        sudo cpan
-        cpan> install RT::Extension::CommandByMail
-        cpan> notest install RT::Extension::MergeUsers
+       sudo cpan
+       cpan> install RT::Extension::CommandByMail
+       cpan> notest install RT::Extension::MergeUsers
 
-  When prompted, the RT lib folder is located at `/usr/share/request-tracker4/lib`.
+   When prompted, the RT lib folder is located at
+   `/usr/share/request-tracker4/lib`.
 
-1. Copy site-specific RT configuration into `/etc/request-tracker4/RT_SiteConfig.d/99-ocf`: (this should be puppeted)
+1. Copy site-specific RT configuration into
+   `/etc/request-tracker4/RT_SiteConfig.d/99-ocf`: (this should be puppeted)
 
-        # Debug - commented out for now
-        #Set($LogToSTDERR, "debug");
-        #Set($LogToSyslog, "debug");
+       # Debug - commented out for now
+       #Set($LogToSTDERR, "debug");
+       #Set($LogToSyslog, "debug");
 
-        Set($WebDomain, 'rt.ocf.berkeley.edu');
-        Set($WebBaseURL , "https://rt.ocf.berkeley.edu");
-        Set($WebPort, 443);
+       Set($WebDomain, 'rt.ocf.berkeley.edu');
+       Set($WebBaseURL , "https://rt.ocf.berkeley.edu");
+       Set($WebPort, 443);
 
-        # Use external authentication provided by mod_auth_kerb
-        Set($WebExternalAuth , 1);
-        Set($WebFallbackToInternalAuth, 1);
-        # tells RT to create users automatically if no user matching REMOTE_USER is found
-        Set($WebExternalAuto, 1);
-        Set($WebExternalGecos, undef);
+       # Use external authentication provided by mod_auth_kerb
+       Set($WebExternalAuth , 1);
+       Set($WebFallbackToInternalAuth, 1);
+       # tells RT to create users automatically if no user matching REMOTE_USER is found
+       Set($WebExternalAuto, 1);
+       Set($WebExternalGecos, undef);
 
-        # Plugins
-        Set(@MailPlugins, qw(Auth::MailFrom Filter::TakeAction));
-        Set(@Plugins,(qw(RT::Extension::CommandByMail RT::Extension::MergeUsers)));
+       # Plugins
+       Set(@MailPlugins, qw(Auth::MailFrom Filter::TakeAction));
+       Set(@Plugins,(qw(RT::Extension::CommandByMail RT::Extension::MergeUsers)));
 
-        # Make links clicky
-        Set(@Active_MakeClicky, qw(httpurl_overwrite));
+       # Make links clicky
+       Set(@Active_MakeClicky, qw(httpurl_overwrite));
 
-        # Non-fail To addresses
-        Set($UseFriendlyToLine, 1);
+       # Non-fail To addresses
+       Set($UseFriendlyToLine, 1);
 
-        # Enable fulltext
-        Set( %FullTextSearch,
-            Enable     => 1,
-            Indexed    => 1,
-            Table      => 'AttachmentsIndex',
-            MaxMatches => '10000',
-        );
+       # Enable fulltext
+       Set( %FullTextSearch,
+           Enable     => 1,
+           Indexed    => 1,
+           Table      => 'AttachmentsIndex',
+           MaxMatches => '10000',
+       );
 
-        # Use plain text instead of HTML email
-        Set($MessageBoxRichText, undef);
-        Set($PreferRichText, undef);
+       # Use plain text instead of HTML email
+       Set($MessageBoxRichText, undef);
+       Set($PreferRichText, undef);
 
-  Remove excess newlines courtesy of ikiwiki.
+   Remove excess newlines courtesy of ikiwiki.
 
-  Regenerate the resultant `RT_SiteConfig.pm` file:
+   Regenerate the resultant `RT_SiteConfig.pm` file:
 
-        sudo update-rt-siteconfig
+       sudo update-rt-siteconfig
 
-6. Ensure that SSL certificates for `rt.ocf.berkeley.edu` exist at the following locations:
-* Certificate: `/etc/ssl/private/rt_ocf_berkeley_edu.crt`
-* Certificate chain/bundle: `/etc/ssl/private/incommon.crt`
-* Private key: `/etc/ssl/private/rt_ocf_berkeley_edu.key`
+6. Ensure that SSL certificates for `rt.ocf.berkeley.edu` exist at the
+   following locations:
+   * Certificate: `/etc/ssl/private/rt_ocf_berkeley_edu.crt`
+   * Certificate chain/bundle: `/etc/ssl/private/incommon.crt`
+   * Private key: `/etc/ssl/private/rt_ocf_berkeley_edu.key`
 
-  **Nginx only:** Create a "chained" certificate file:
+   **Nginx only:** Create a "chained" certificate file:
 
-        cat rt_ocf_berkeley_edu.crt incommon.crt > rt_ocf_berkeley_edu.chained.crt
+       cat rt_ocf_berkeley_edu.crt incommon.crt > rt_ocf_berkeley_edu.chained.crt
 
-7. **For Apache 2:** Copy the following RT configuration file `rt` into `/etc/apache2/sites-available` and link to it from `/etc/apache2/sites-enabled` (replace typhoon.ocf.berkeley.edu with the FQDN reported by `hostname -f`):
+7. **For Apache 2:** Copy the following RT configuration file `rt` into
+   `/etc/apache2/sites-available` and link to it from
+   `/etc/apache2/sites-enabled` (replace typhoon.ocf.berkeley.edu with the FQDN
+   reported by `hostname -f`):
 
-        # Apache configuration file for RT
+       # Apache configuration file for RT
 
-        <VirtualHost *:80>
-                ServerName rt.ocf.berkeley.edu
-                RewriteEngine On
-                RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
-        </VirtualHost>
+       <VirtualHost *:80>
+               ServerName rt.ocf.berkeley.edu
+               RewriteEngine On
+               RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
+       </VirtualHost>
+
+       <VirtualHost *:443>
+               ServerName rt.ocf.berkeley.edu
+
+               SSLEngine on
+               SSLCertificateFile /etc/ssl/private/rt_ocf_berkeley_edu.crt
+               SSLCertificateChainFile /etc/ssl/private/incommon.crt
+               SSLCertificateKeyFile /etc/ssl/private/rt_ocf_berkeley_edu.key
+
+               Alias /rt /usr/share/request-tracker4/html
+               RedirectMatch ^/$ /rt
+
+               <Location /rt>
+                       SetHandler modperl
+                       PerlResponseHandler Plack::Handler::Apache2
+                       PerlSetVar psgi_app /usr/share/request-tracker4/libexec/rt-server
+
+                       # Comment this to enable RT-local root
+                       AuthType Kerberos
+                       Require valid-user
+                       KrbMethodNegotiate On
+                       KrbMethodK5Passwd On
+                       KrbLocalUserMapping On
+                       KrbServiceName HTTP/typhoon.ocf.berkeley.edu
+                       Krb5KeyTab /etc/apache2/sites-available/rt.keytab
+               </Location>
+
+               <Location /rt/REST/1.0/NoAuth>
+                       # No Kerberos - for rt-mailgate
+                       Satisfy Any
+                       Order Allow,Deny
+                       Allow from 128.32.129.218 # sandstorm.ocf.berkeley.edu
+               </Location>
+
+               <Location /rt/NoAuth>
+                       # No Kerberos - login/logout pages
+                       Satisfy Any
+                       Order Allow,Deny
+                       Allow from All
+               </Location>
+
+               <Perl>
+                       use Plack::Handler::Apache2;
+                       Plack::Handler::Apache2->preload("/usr/share/request-tracker4/libexec/rt-server");
+               </Perl>
 
-        <VirtualHost *:443>
-                ServerName rt.ocf.berkeley.edu
+       </VirtualHost>
 
-                SSLEngine on
-                SSLCertificateFile /etc/ssl/private/rt_ocf_berkeley_edu.crt
-                SSLCertificateChainFile /etc/ssl/private/incommon.crt
-                SSLCertificateKeyFile /etc/ssl/private/rt_ocf_berkeley_edu.key
-
-                Alias /rt /usr/share/request-tracker4/html
-                RedirectMatch ^/$ /rt
-
-                <Location /rt>
-                        SetHandler modperl
-                        PerlResponseHandler Plack::Handler::Apache2
-                        PerlSetVar psgi_app /usr/share/request-tracker4/libexec/rt-server
-
-                        # Comment this to enable RT-local root
-                        AuthType Kerberos
-                        Require valid-user
-                        KrbMethodNegotiate On
-                        KrbMethodK5Passwd On
-                        KrbLocalUserMapping On
-                        KrbServiceName HTTP/typhoon.ocf.berkeley.edu
-                        Krb5KeyTab /etc/apache2/sites-available/rt.keytab
-                </Location>
-
-                <Location /rt/REST/1.0/NoAuth>
-                        # No Kerberos - for rt-mailgate
-                        Satisfy Any
-                        Order Allow,Deny
-                        Allow from 128.32.129.218 # sandstorm.ocf.berkeley.edu
-                </Location>
-
-                <Location /rt/NoAuth>
-                        # No Kerberos - login/logout pages
-                        Satisfy Any
-                        Order Allow,Deny
-                        Allow from All
-                </Location>
-
-                <Perl>
-                        use Plack::Handler::Apache2;
-                        Plack::Handler::Apache2->preload("/usr/share/request-tracker4/libexec/rt-server");
-                </Perl>
-
-        </VirtualHost>
-
-  I would like to sincerely apologize for the terrible job ikiwiki has done of mangling this and promise it will look better soon.
-
-  **For Nginx:** Copy the following RT configuration file `rt` into `/etc/nginx/sites-available` and link to it from `/etc/nginx/sites-enabled`:
-
-        # Configuration for RT on Nginx
-        # rt.ocf.berkeley.edu
-
-        server {
-                listen 80;
-                server_name rt.ocf.berkeley.edu;
-                rewrite ^ https://$server_name$request_uri? permanent;
-        }
-
-
-        server {
-                listen 443;
-                server_name rt.ocf.berkeley.edu;
-                rewrite ^/$ /rt;
-
-                root /usr/share/request-tracker4;
-
-                location /rt {
-                        # See /usr/share/doc/rt4-fcgi/examples/request-tracker4.conf
-                        expires epoch;
-
-                        # Require the default authentication on typhoon (pam_krb5)
-                        auth_pam "RT";
-                        auth_pam_service_name "common-password";
-
-                        # Proxy over to rt4.
-                        fastcgi_pass unix:/var/run/rt4-fcgi.sock;
-                        include /etc/nginx/fastcgi_params;
-                        fastcgi_param REMOTE_USER $remote_user;
-                        fastcgi_param SCRIPT_NAME "/rt";
-                }
-
-                # Bypass FastCGI for images
-                location /rt/NoAuth/images {
-                        alias           /usr/share/request-tracker4/html/NoAuth/images/;
-                }
-
-                location /rt/REST/1.0/NoAuth {
-                        allow           128.32.129.218; # sandstorm.ocf.berkeley.edu
-                        deny            all;
-
-                        fastcgi_pass unix:/var/run/rt4-fcgi.sock;
-                        include /etc/nginx/fastcgi_params;
-                        fastcgi_param REMOTE_USER $remote_user;
-                        fastcgi_param SCRIPT_NAME "/rt";
-                }
-
-                ssl on;
-
-                # Same as apache
-                ssl_certificate /etc/ssl/private/rt_ocf_berkeley_edu.chained.crt;
-                ssl_certificate_key /etc/ssl/private/rt_ocf_berkeley_edu.key;
-
-                ssl_session_timeout 5m;
-                ssl_session_cache shared:SSL:10m;
-
-                ssl_protocols SSLv3 TLSv1;
-                ssl_ciphers ALL:!ADH:!EXPORT56:RC4+RSA:+HIGH:+MEDIUM:+LOW:+SSLv3:+EXP;
-                ssl_prefer_server_ciphers on;
-        }
-
-  Remove extraneous newlines inserted by ikiwiki.
-
-8. **Apache 2 only:** Obtain a keytab for the principal HTTP/typhoon.ocf.berkeley.edu@OCF.BERKELEY.EDU (replace typhoon.ocf.berkeley.edu with the FQDN reported by `hostname -f`) and place it into `/etc/apache2/sites-available/rt.keytab`. Make sure it's only readable by www-data.
-
-8. mod_auth_kerb/ngx_http_auth_pam uses HTTP Basic authorization which has no concept of login/logout. Emulate logout behavior by changing the Logout page to send a 401 (works for Chrome), run proprietary IE code (works for IE), and make an Ajax call to a non-existing page with bad credentials (works for Firefox).
-
-  The below code has been "adapted" from https://trac-hacks.org/wiki/TrueHttpLogoutPatch
-
-  This should be fixed so that RT's installation files aren't being directly modified.
-
-  Edit `/usr/share/request-tracker4/html/NoAuth/Logout.html`:
-
-  Change
-
-        <& /Elements/Header, Title => loc('Logout'), Refresh => RT->Config->Get('LogoutRefresh') &>
-
-  to
-
-        <& /Elements/Header, Title => loc('Logout') &>
-
-  and paste the following below it:
-
-        <script type="text/javascript">
-        function clearAuthenticationCache() {
-          try {
-            var agent = navigator.userAgent.toLowerCase();
-            if (agent.indexOf("msie") != -1) {
-              // This works only on IE only.
-              document.execCommand("ClearAuthenticationCache");
-            }
-            else {
-              var xml = createXMLObject();
-              // Let's prepare invalid credentials
-              xml.open("GET", Math.random().toString(), true, "logout", "logout");
-              xml.send("");
-              xml.abort();
-            }
-          } catch (e) {
-            return;
-          }
-        }
-
-        function createXMLObject() {
-          try {
-            if (window.XMLHttpRequest) {
-              xml = new XMLHttpRequest();
-            }
-            else if (window.ActiveXObject) {
-              xml = new ActiveXObject("Microsoft.XMLHTTP");
-            }
-          } catch (e) {
-            xml = false
-          }
-          return xml;
-        }
-
-        clearAuthenticationCache();
-        </script>
-
-  Add the following before the end of the <%INIT> block at the end of the file:
-
-        # "Force" logout due to using mod_auth_kerb -- Chrome
-        $HTML::Mason::Commands::r->status(401);
-
-  Clear the RT Mason cache.
-
-        sudo rm -rf /var/cache/request-tracker4/*
-
+   I would like to sincerely apologize for the terrible job ikiwiki has done of
+   mangling this and promise it will look better soon.
+
+   **For Nginx:** Copy the following RT configuration file `rt` into
+   `/etc/nginx/sites-available` and link to it from `/etc/nginx/sites-enabled`:
+
+       # Configuration for RT on Nginx
+       # rt.ocf.berkeley.edu
+
+       server {
+               listen 80;
+               server_name rt.ocf.berkeley.edu;
+               rewrite ^ https://$server_name$request_uri? permanent;
+       }
+
+       server {
+               listen 443;
+               server_name rt.ocf.berkeley.edu;
+               rewrite ^/$ /rt;
+
+               root /usr/share/request-tracker4;
+
+               location /rt {
+                       # See /usr/share/doc/rt4-fcgi/examples/request-tracker4.conf
+                       expires epoch;
+
+                       # Require the default authentication on typhoon (pam_krb5)
+                       auth_pam "RT";
+                       auth_pam_service_name "common-password";
+
+                       # Proxy over to rt4.
+                       fastcgi_pass unix:/var/run/rt4-fcgi.sock;
+                       include /etc/nginx/fastcgi_params;
+                       fastcgi_param REMOTE_USER $remote_user;
+                       fastcgi_param SCRIPT_NAME "/rt";
+               }
+
+               # Bypass FastCGI for images
+               location /rt/NoAuth/images {
+                       alias           /usr/share/request-tracker4/html/NoAuth/images/;
+               }
+
+               location /rt/REST/1.0/NoAuth {
+                       allow           128.32.129.218; # sandstorm.ocf.berkeley.edu
+                       deny            all;
+
+                       fastcgi_pass unix:/var/run/rt4-fcgi.sock;
+                       include /etc/nginx/fastcgi_params;
+                       fastcgi_param REMOTE_USER $remote_user;
+                       fastcgi_param SCRIPT_NAME "/rt";
+               }
+
+               ssl on;
+
+               # Same as apache
+               ssl_certificate /etc/ssl/private/rt_ocf_berkeley_edu.chained.crt;
+               ssl_certificate_key /etc/ssl/private/rt_ocf_berkeley_edu.key;
+
+               ssl_session_timeout 5m;
+               ssl_session_cache shared:SSL:10m;
+
+               ssl_protocols SSLv3 TLSv1;
+               ssl_ciphers ALL:!ADH:!EXPORT56:RC4+RSA:+HIGH:+MEDIUM:+LOW:+SSLv3:+EXP;
+               ssl_prefer_server_ciphers on;
+       }
+
+   Remove extraneous newlines inserted by ikiwiki.
+
+8. **Apache 2 only:** Obtain a keytab for the principal
+   HTTP/typhoon.ocf.berkeley.edu@OCF.BERKELEY.EDU (replace
+   typhoon.ocf.berkeley.edu with the FQDN reported by `hostname -f`) and place
+   it into `/etc/apache2/sites-available/rt.keytab`. Make sure it's only
+   readable by www-data.
+
+8. mod_auth_kerb/ngx_http_auth_pam uses HTTP Basic authorization which has no
+   concept of login/logout. Emulate logout behavior by changing the Logout page
+   to send a 401 (works for Chrome), run proprietary IE code (works for IE),
+   and make an Ajax call to a non-existing page with bad credentials (works for
+   Firefox).
+
+   The below code has been "adapted" from https://trac-hacks.org/wiki/TrueHttpLogoutPatch
+
+   This should be fixed so that RT's installation files aren't being directly modified.
+
+   Edit `/usr/share/request-tracker4/html/NoAuth/Logout.html`:
+
+   Change
+
+       <& /Elements/Header, Title => loc('Logout'), Refresh => RT->Config->Get('LogoutRefresh') &>
+
+   to
+
+       <& /Elements/Header, Title => loc('Logout') &>
+
+   and paste the following below it:
+
+       <script type="text/javascript">
+       function clearAuthenticationCache() {
+         try {
+           var agent = navigator.userAgent.toLowerCase();
+           if (agent.indexOf("msie") != -1) {
+             // This works only on IE only.
+             document.execCommand("ClearAuthenticationCache");
+           }
+           else {
+             var xml = createXMLObject();
+             // Let's prepare invalid credentials
+             xml.open("GET", Math.random().toString(), true, "logout", "logout");
+             xml.send("");
+             xml.abort();
+           }
+         } catch (e) {
+           return;
+         }
+       }
+
+       function createXMLObject() {
+         try {
+           if (window.XMLHttpRequest) {
+             xml = new XMLHttpRequest();
+           }
+           else if (window.ActiveXObject) {
+             xml = new ActiveXObject("Microsoft.XMLHTTP");
+           }
+         } catch (e) {
+           xml = false
+         }
+         return xml;
+       }
+
+       clearAuthenticationCache();
+       </script>
+
+   Add the following before the end of the <%INIT> block at the end of the file:
+
+       # "Force" logout due to using mod_auth_kerb -- Chrome
+       $HTML::Mason::Commands::r->status(401);
+
+   Clear the RT Mason cache.
+
+       sudo rm -rf /var/cache/request-tracker4/*
 
 8. **For Apache 2:** Restart Apache.
 
-  **For Nginx:** Restart the RT FastCGI daemon.
+   **For Nginx:** Restart the RT FastCGI daemon.
 
-        sudo service rt4-fcgi restart
+       sudo service rt4-fcgi restart
 
-9. Install the RT [mailgate program](http://requesttracker.wikia.com/wiki/EmailInterface#RT.27s_mail_gate) on the mail server.
+9. Install the RT [mailgate
+   program](http://requesttracker.wikia.com/wiki/EmailInterface#RT.27s_mail_gate)
+   on the mail server.
 
-  squeeze-backports is required here too.
+   squeeze-backports is required here too.
 
-        sudo aptitude install rt4-clients
+       sudo aptitude install rt4-clients
 
 10. Set up rt@ocf.berkeley.edu to feed mail into rt-mailgate.
 
-  Add or edit the following lines into `/var/mail/aliases/aliases`:
+    Add or edit the following lines into `/var/mail/aliases/aliases`:
 
         rt: "|/usr/bin/rt-mailgate --queue General --action correspond --url https://rt.ocf.berkeley.edu/rt"
         rt-comment: "|/usr/bin/rt-mailgate --queue General --action comment --url https://rt.ocf.berkeley.edu/rt"
 
 ## Configuration
 
-1. The RT root user can't log in while Kerberos password authentication is enabled because of the way `mod_auth_kerb/ngx_http_auth_pam` works. So, you must first log in with Kerberos credentials to create a user from Kerberos and grant superuser rights on it.
+1. The RT root user can't log in while Kerberos password authentication is
+   enabled because of the way `mod_auth_kerb/ngx_http_auth_pam` works. So, you
+   must first log in with Kerberos credentials to create a user from Kerberos
+   and grant superuser rights on it.
 
-  Log in to RT. You will be auto-created and redirected to Self-Service.
-  Disable Kerberos password authentication:
+   Log in to RT. You will be auto-created and redirected to Self-Service.
+   Disable Kerberos password authentication:
 
-  **Apache 2:** Comment out the following lines in `/etc/apache2/sites-available/rt`:
+   **Apache 2:** Comment out the following lines in `/etc/apache2/sites-available/rt`:
 
-        # AuthType Kerberos
-        # Require valid-user
+       # AuthType Kerberos
+       # Require valid-user
 
-  and force-reload Apache configuration (`service apache2 force-reload`).
+   and force-reload Apache configuration (`service apache2 force-reload`).
 
-  **Nginx:** Comment out the following lines in `/etc/nginx/sites-available/rt`:
+   **Nginx:** Comment out the following lines in `/etc/nginx/sites-available/rt`:
 
-        # auth_pam "RT";
-        # auth_pam_service_name "common-password";
+       # auth_pam "RT";
+       # auth_pam_service_name "common-password";
 
-  and restart Nginx (`service nginx restart`).
+   and restart Nginx (`service nginx restart`).
 
 1. Visit RT again and log in as RT root.
 
-  Go to Tools > Configuration > Users > Select, and type in your username in "Go to user". Enable **Let this user be granted rights (Privileged)**.
+   Go to Tools > Configuration > Users > Select, and type in your username in
+   "Go to user". Enable **Let this user be granted rights (Privileged)**.
 
-  Go to Tools > Configuration > Global > User Rights. On the left side, in Add User, type your name. Then, on the right side, click the tab **Rights for Administrators**, and enable **Do anything and everything**.
+   Go to Tools > Configuration > Global > User Rights. On the left side, in Add
+   User, type your name. Then, on the right side, click the tab **Rights for
+   Administrators**, and enable **Do anything and everything**.
 
-  Save changes.
+   Save changes.
 
-  You will want to remove your superuser powers later because superusers may be artificially limited in rights elsewhere on RT for your own protection: ["Starting from version 3.2 (or 3.4?) RT doesn't show users with the SuperUser right in a ticket owner select-box."](http://requesttracker.wikia.com/wiki/SuperUser)
+   You will want to remove your superuser powers later because superusers may
+   be artificially limited in rights elsewhere on RT for your own protection:
+   ["Starting from version 3.2 (or 3.4?) RT doesn't show users with the
+   SuperUser right in a ticket owner
+   select-box."](http://requesttracker.wikia.com/wiki/SuperUser)
 
-  Re-enable Kerberos password authentication in Apache configuration and force-reload Apache.
+   Re-enable Kerberos password authentication in Apache configuration and
+   force-reload Apache.
 
-1. Create groups. I've created root and staff groups; this configuration may change as our use of RT is refined.
+1. Create groups. I've created root and staff groups; this configuration may
+   change as our use of RT is refined.
 
-  Go to Tools > Configuration > Groups > Create and create "Root" and "Staff" groups.
+   Go to Tools > Configuration > Groups > Create and create "Root" and "Staff"
+   groups.
 
-  Add users to these groups by the **Members** subsection in the upper right corner of the group modification page. (You can also alter a user's group memberships from the user's modification page.)
+   Add users to these groups by the **Members** subsection in the upper right
+   corner of the group modification page. (You can also alter a user's group
+   memberships from the user's modification page.)
 
-  In this configuration I see the set of RT privileged users to be the same as the set of users in group "Staff". This may change.
+   In this configuration I see the set of RT privileged users to be the same as
+   the set of users in group "Staff". This may change.
 
-2. Enable user rights. [This](http://requesttracker.wikia.com/wiki/Rights) guide is being followed.
+2. Enable user rights. [This](http://requesttracker.wikia.com/wiki/Rights)
+   guide is being followed.
 
-  Go to Tools > Configuration > Global > Group Rights.
+   Go to Tools > Configuration > Global > Group Rights.
 
-  **Save your changes each time you make changes to a group's rights.**
+   **Save your changes each time you make changes to a group's rights.**
 
-  Make sure the selected group is **Everyone**.
+   Make sure the selected group is **Everyone**.
 
-  Select the following rights:
-    - Comment on tickets
-    - Create tickets
-    - Reply to tickets
-    - View queue
-    - View ticket summaries
+   Select the following rights:
+   - Comment on tickets
+   - Create tickets
+   - Reply to tickets
+   - View queue
+   - View ticket summaries
 
-  Now add a group to add permissions to, from the bottom left: Add Group
+   Now add a group to add permissions to, from the bottom left: Add Group
 
-  Add these rights to "Staff", in the "Rights for Staff" tab:
-    - Delete tickets
-    - Modify one's own RT account
-    - Modify tickets
-    - Own tickets
-    - Steal tickets
-    - Take tickets
-    - View private ticket commentary
+   Add these rights to "Staff", in the "Rights for Staff" tab:
+   - Delete tickets
+   - Modify one's own RT account
+   - Modify tickets
+   - Own tickets
+   - Steal tickets
+   - Take tickets
+   - View private ticket commentary
 
-  Add these rights to "Root", in the "Rights for Administrators" tab:
-    - Everything except "Do anything and everything"
+   Add these rights to "Root", in the "Rights for Administrators" tab:
+   - Everything except "Do anything and everything"
 
 3. Miscellaneous configuration
 
-  Change RT root's info so he can be a front for staff@. (Tools > Configuration > Users > Select, click root, change email to staff@ocf.berkeley.edu and Real Name to OCF Staff).
+   Change RT root's info so he can be a front for staff@. (Tools >
+   Configuration > Users > Select, click root, change email to
+   staff@ocf.berkeley.edu and Real Name to OCF Staff).
 
-  Make the General queue sound better: Tools > Configuration > Queues > Select, click General, change Description to "OCF Staff". (I think changing the Queue Name would be nice too. If you do that, remember to change the parameters to rt-mailgate in `/var/mail/aliases/aliases` and re-run newaliases on sandstorm.)
+   Make the General queue sound better: Tools > Configuration > Queues >
+   Select, click General, change Description to "OCF Staff". (I think changing
+   the Queue Name would be nice too. If you do that, remember to change the
+   parameters to rt-mailgate in `/var/mail/aliases/aliases` and re-run
+   newaliases on sandstorm.)
 
-  Add root as a watcher for General so staff@ gets automatically Cc'ed to new tickets. Click Watchers in the upper right corner and add root.
+   Add root as a watcher for General so staff@ gets automatically Cc'ed to new
+   tickets. Click Watchers in the upper right corner and add root.
 
 4. Send more mail.
 
-  By default RT only sends an autoreply to the requestor on ticket creation. Create a new scrip (RT callback) so that Cc (staff@) gets notified on ticket creation as well.
+   By default RT only sends an autoreply to the requestor on ticket creation.
+   Create a new scrip (RT callback) so that Cc (staff@) gets notified on ticket
+   creation as well.
 
-  Create that which is to be mailed: go to Tools > Configuration > Global > Templates > Create.
+   Create that which is to be mailed: go to Tools > Configuration > Global >
+   Templates > Create.
 
-  Create a template with the name "Correspondence Creation" and description "For mailing staff on ticket creation, but without all that boilerplate". Keep type as "Perl". Paste this in as the content:
+   Create a template with the name "Correspondence Creation" and description
+   "For mailing staff on ticket creation, but without all that boilerplate".
+   Keep type as "Perl". Paste this in as the content:
 
-        RT-Attach-Message: yes
-        Subject: {$Ticket->Subject}
+       RT-Attach-Message: yes
+       Subject: {$Ticket->Subject}
 
-        {$Transaction->Content()}
+       {$Transaction->Content()}
 
-  Remove the second newline caused by using ikiwiki.
+   Remove the second newline caused by using ikiwiki.
 
-  Save changes.
+   Save changes.
 
-  Modify the scrip "On Create Notify AdminCcs" to use the template "Global Template: Correspondence Creation".
+   Modify the scrip "On Create Notify AdminCcs" to use the template "Global Template: Correspondence Creation".
 
 4. Send spoofed mail.
 
-  Mail in the past has come from actual people, not endless drones of "via RT". Let's fake that for people who are uncomfortable with change. At the top of Correspondence, Admin Correspondence, Admin Comment, and Correspondence Creation templates, append the following below the last mail header that appears, if any exist:
+   Mail in the past has come from actual people, not endless drones of "via
+   RT". Let's fake that for people who are uncomfortable with change. At the
+   top of Correspondence, Admin Correspondence, Admin Comment, and
+   Correspondence Creation templates, append the following below the last mail
+   header that appears, if any exist:
 
-        From: {
-          my $u = $Transaction->CreatorObj;
-          my $a = $u->EmailAddress;
-          my $res = $u->RealName || $u->Name;
-          $res .= " <".$a .">" ;
-        $res; }
+       From: {
+         my $u = $Transaction->CreatorObj;
+         my $a = $u->EmailAddress;
+         my $res = $u->RealName || $u->Name;
+         $res .= " <".$a .">" ;
+       $res; }
 
 5. Automatically close tickets.
 
-  This needs to be chained or something to send a template saying that the ticket is closed because it hasn't been modified in 30 days. I don't know what this entails, but the below is a start.
+   This needs to be chained or something to send a template saying that the
+   ticket is closed because it hasn't been modified in 30 days. I don't know
+   what this entails, but the below is a start.
 
-  Put the following into a crontab; you may want to create a rt system user to run this.
+   Put the following into a crontab; you may want to create a rt system user to
+   run this.
 
-        0 * * * * /usr/bin/rt-crontool --search RT::Search::FromSQL \
-        --search-arg "LastUpdated < '5 days ago' AND Status = 'stalled'" \
-        --action RT::Action::SetStatus --action-arg resolved
+       0 * * * * /usr/bin/rt-crontool --search RT::Search::FromSQL \
+       --search-arg "LastUpdated < '5 days ago' AND Status = 'stalled'" \
+       --action RT::Action::SetStatus --action-arg resolved
 
-  References: [1](http://lists.bestpractical.com/pipermail/rt-users/2005-February/028837.html) [2](http://requesttracker.wikia.com/wiki/UntouchedInHours) [3](http://requesttracker.wikia.com/wiki/TimedNotifications)
+   References:
+   [1](http://lists.bestpractical.com/pipermail/rt-users/2005-February/028837.html)
+   [2](http://requesttracker.wikia.com/wiki/UntouchedInHours)
+   [3](http://requesttracker.wikia.com/wiki/TimedNotifications)
 
 ## Notes
-* First-time autocreated users will have incorrect/embarrassing Real Names (for some reason, it grabs the gecos on occasion), so that should be fixed upon first login. Users can also update this information when they feel like it.
+
+* First-time autocreated users will have incorrect/embarrassing Real Names (for
+  some reason, it grabs the gecos on occasion), so that should be fixed upon
+  first login. Users can also update this information when they feel like it.
 
 ## Todo
+
 * Fix Chrome double login, if possible.
-** Doesn't occur when running Nginx, only Apache 2.
-* Set up ticket autoclose using http://requesttracker.wikia.com/wiki/UntouchedInHours or http://requesttracker.wikia.com/wiki/TimedNotifications
+  * Doesn't occur when running Nginx, only Apache 2.
+* Set up ticket autoclose using
+  http://requesttracker.wikia.com/wiki/UntouchedInHours or
+  http://requesttracker.wikia.com/wiki/TimedNotifications
 
 ## References
+
 * http://requesttracker.wikia.com/wiki/HomePage

--- a/ocfweb/docs/docs/staff/scripts/approve.md
+++ b/ocfweb/docs/docs/staff/scripts/approve.md
@@ -1,13 +1,15 @@
 [[!meta title="approve: record an OCF account request"]]
-This page explains the OCF account approval procedure and the usage of
-the `approve` script.
+
+This page explains the OCF account approval procedure and the usage of the
+`approve` script.
 
 ## When to use approve
+
 OCF group accounts need to be manually approved by staff in the lab. All
 members requesting individual accounts should be directed to the online
-approval page. If a member requesting an individual account cannot use
-the online approval system (likely because of an invalid/unacceptable
-CalNet UID), direct them to an OCF officer.
+approval page. If a member requesting an individual account cannot use the
+online approval system (likely because of an invalid/unacceptable CalNet UID),
+direct them to an OCF officer.
 
 ## Approving a request
 
@@ -16,14 +18,15 @@ CalNet UID), direct them to an OCF officer.
 ### Before approve
 
 * SSH into supernova.ocf.berkeley.edu
-* For registered student groups, the OCF requires that a signatory
-  authorize the approval of the account. If the account is not a
-  registered student group, check with the [[membership eligibility|doc
-  membership/eligibility]] to see what constitutes acceptable
-  documentation.
-* If the group is a registered student group, you can look up the
-  requester's signatory status by name with [[signat|doc
-  staff/scripts/signat]].
+
+* For registered student groups, the OCF requires that a signatory authorize
+  the approval of the account. If the account is not a registered student
+  group, check with the [[membership eligibility|doc membership/eligibility]]
+  to see what constitutes acceptable documentation.
+
+* If the group is a registered student group, you can look up the requester's
+  signatory status by name with [[signat|doc staff/scripts/signat]].
+
   ```text
   $ signat name matthew mcallister
   Searching for people... Found 1 entry.
@@ -35,15 +38,19 @@ CalNet UID), direct them to an OCF officer.
   -----------------------  ---------------------------  -----
   Open Computing Facility  decal, linux, ggroup, group  46187
   ```
+
   Copy the group's OID, as you will need it when running approve.
+
 * If the group is not a student group, the requester will need official
-  letterhead giving them authority to create the account. You will also
-  need to check that the group doesn't already have an account using
+  letterhead giving them authority to create the account. You will also need to
+  check that the group doesn't already have an account using
   `checkacct`.
+
   ```text
   $ checkacct privacy
   Login: bipla              Name: Berkeley Information Privacy Law Association
   ```
+
 * Finally, check that the name on the requester's Cal ID matches who
   they say they are.
 
@@ -54,12 +61,12 @@ When you run approve it will open a text editor; just fill out the form,
 save it, and let the requester enter a password when prompted.
 
 Optionally, if you pass the OID as the only argument, the `group_name`,
-`callink_oid`, and `email` fields will get filled in automatically using
-the group's public information on CalLink.
+`callink_oid`, and `email` fields will get filled in automatically using the
+group's public information on CalLink.
 
 
 ### Post approval
 
 Explain to the requesters that they will need to apply for [[virtual
-hosting|doc services/vhost]] after they have set up their site if they
-wish to do so. Point them to relevant wiki articles.
+hosting|doc services/vhost]] after they have set up their site if they wish to
+do so. Point them to relevant wiki articles.

--- a/ocfweb/docs/docs/staff/scripts/check.md
+++ b/ocfweb/docs/docs/staff/scripts/check.md
@@ -2,7 +2,9 @@
 
 ## Introduction
 
-Check allows a staffer to get all the usage details of a user. Some information may only be accessible to privileged users or root, and dependent on local machine, so the output may differ accordingly.
+Check allows a staffer to get all the usage details of a user. Some information
+may only be accessible to privileged users or root, and dependent on local
+machine, so the output may differ accordingly.
 
 ## Usage/Example
 

--- a/ocfweb/docs/docs/staff/scripts/checkacct.md
+++ b/ocfweb/docs/docs/staff/scripts/checkacct.md
@@ -2,11 +2,19 @@
 
 ## Introduction
 
-If a member does not know their account name, you can use this script to look it up.
+If a member does not know their account name, you can use this script to look
+it up.
 
-Before recording an account request for a group with [[approve|doc staff/scripts/approve]], check to see if the group already has an account. Be sure to use different forms and abbreviations of the group's name to maximize the chance that a group will be found.
+Before recording an account request for a group with [[approve|doc
+staff/scripts/approve]], check to see if the group already has an account. Be
+sure to use different forms and abbreviations of the group's name to maximize
+the chance that a group will be found.
 
-This script will search [[LDAP|doc staff/backend/ldap]] for case-insensitive matches in any part of the full name or account name, including part of a word. For example, `checkacct wa fel andy` will search for any account that has "wa" (as in waf), "fel" (as in Felix), and "andy" (as in Andy) in the full name (LDAP cn) or account name (LDAP uid).
+This script will search [[LDAP|doc staff/backend/ldap]] for case-insensitive
+matches in any part of the full name or account name, including part of a word.
+For example, `checkacct wa fel andy` will search for any account that has "wa"
+(as in waf), "fel" (as in Felix), and "andy" (as in Andy) in the full name
+(LDAP cn) or account name (LDAP uid).
 
 ## Usage
 

--- a/ocfweb/docs/docs/staff/scripts/chpass.md
+++ b/ocfweb/docs/docs/staff/scripts/chpass.md
@@ -7,11 +7,13 @@ group accounts or users that send notarized letters to the OCF.
 
 ## Technical Description
 
-Perl script that changes a user's kerberos principal password using a specified staff/root principal.
+Perl script that changes a user's kerberos principal password using a specified
+staff/root principal.
 
 ## Usage
 
     ~$ chpass andromeda
+
 Changes user andromeda's password
 
 ## Sample Use Case
@@ -26,12 +28,17 @@ You can run chpass on any server.
     member may have.
 
     Changing password for: andromeda:*:1615:20:Andromeda Centauri,The OCF,,:/home/a/an/andromeda:/opt/share/utils/bin/sorried
-Let the user type in his new password (and verify it).  Requirements are for passwords to be at least 8 characters long.  It is helpful to indicate that nothing will show up when the user starts typing.
+
+Let the user type in his new password (and verify it). Requirements are for
+passwords to be at least 8 characters long. It is helpful to indicate that
+nothing will show up when the user starts typing.
 
     Enter New Password:
     Verify password:
     Connecting to kerberos.ocf.berkeley.edu...
-Now type in your kerberos root principal password.  If you don't have one you can't change passwords!
+
+Now type in your kerberos root principal password. If you don't have one you
+can't change passwords!
 
     Please enter the password for principal raphtown/root:
     andromeda@OCF.BERKELEY.EDU's Password:

--- a/ocfweb/docs/docs/staff/scripts/migrate-vm.md
+++ b/ocfweb/docs/docs/staff/scripts/migrate-vm.md
@@ -21,9 +21,10 @@ To move the virtual machine, `migrate-vm` performs the following steps:
 
 1. Shuts down the virtual machine on the old host.
 2. Creates a new [LVM][lvm] volume on the new host with the correct size.
-3. Securely copies the virtual machine's disk from the old host to the new host.
+3. Securely copies the virtual machine's disk from the old host to the new
+   host.
 4. Checksums both the old and the new disks on each machine to ensure they
-match.
+   match.
 5. Imports the KVM domain definition from the old host to the new host.
 
 [lvm]: https://wiki.debian.org/LVM
@@ -31,10 +32,10 @@ match.
 ## Final steps
 
 After the virtual machine has been transferred between hosts, make sure the
-guest works on the new host. If moving from `hal`, you might need to delete
-the custom CPU definition section from the KVM XML to get the virtual machine
-to start. To edit the XML definition, run `sudo virsh edit ${hostname}`.
-The section to delete looks like this:
+guest works on the new host. If moving from `hal`, you might need to delete the
+custom CPU definition section from the KVM XML to get the virtual machine to
+start. To edit the XML definition, run `sudo virsh edit ${hostname}`. The
+section to delete looks like this:
 
 ```xml
 <cpu mode='custom' match='exact'>

--- a/ocfweb/docs/docs/staff/scripts/paper.md
+++ b/ocfweb/docs/docs/staff/scripts/paper.md
@@ -8,9 +8,9 @@ that is also checked to make sure users have enough print quota before sending
 their document(s) to the printer. This database can be queried and modified by
 the `paper` script, which internally uses `ocflib` to access the database.
 
-The `paper` script can be used from anywhere to list pages remaining per day and
-per semester, but can currently only be used to change print quotas by issuing
-refunds from `supernova`.
+The `paper` script can be used from anywhere to list pages remaining per day
+and per semester, but can currently only be used to change print quotas by
+issuing refunds from `supernova`.
 
 ## Usage Scenarios
 
@@ -19,7 +19,6 @@ refunds from `supernova`.
     $ paper -h
     $ paper view -h
     $ paper refund -h
-
 
 ### View balances
 

--- a/ocfweb/docs/docs/staff/scripts/signat.md
+++ b/ocfweb/docs/docs/staff/scripts/signat.md
@@ -2,18 +2,18 @@
 
 ## Introduction
 
-The `signat` script is used to look up the signatory status of people
-and student groups. This allows us to verify that the people who email
-us or come in to [[staff hours|staff-hours]] are really signatories for their group, and
+The `signat` script is used to look up the signatory status of people and
+student groups. This allows us to verify that the people who email us or come
+in to [[staff hours|staff-hours]] are really signatories for their group, and
 it also gives all the information needed to create group accounts with
 [[approve|doc staff/scripts/approve]].
 
 ## How it works
 
-`signat` is an interface to the [`ocflib`][ocflib] functions to query
-the [CalLink API][callinkapi] for group signatories. `ocflib` is also
-used to look up UIDs and OIDs in OCF [[LDAP|doc staff/backend/ldap]] and
-names in the university's [LDAP directory service][berkeleyldap].
+`signat` is an interface to the [`ocflib`][ocflib] functions to query the
+[CalLink API][callinkapi] for group signatories. `ocflib` is also used to look
+up UIDs and OIDs in OCF [[LDAP|doc staff/backend/ldap]] and names in the
+university's [LDAP directory service][berkeleyldap].
 
 [ocflib]: github.com/ocf/ocflib
 [callinkapi]: https://studentservices.berkeley.edu/WebServices/StudentGroupServiceV2/Service.asmx
@@ -42,9 +42,9 @@ subcommands:
     group               Look up the signatories of a group by group name
 ```
 
-`group` and `name` are the easiest queries to use when a group or
-signatory doesn't already have an OCF account. These perform a keyword
-search for people or groups by name.
+`group` and `name` are the easiest queries to use when a group or signatory
+doesn't already have an OCF account. These perform a keyword search for people
+or groups by name.
 
 ```text
 $ signat name N Impicciche
@@ -81,8 +81,8 @@ DORJEE TASHI        1110958
 TENZING DOLMA       1027935
 ```
 
-`user` looks up an OCF account and prints the signatories for a group
-account or the signatory status of an individual account.
+`user` looks up an OCF account and prints the signatories for a group account
+or the signatory status of an individual account.
 
 ```text
 $ signat user nickimp
@@ -104,8 +104,8 @@ Jasmine Chiman STOY      995773
 AMRIT MAHADEVAN AYALUR  1027142
 ```
 
-The other two queries, `uid` and `oid`, don't offer much convenience,
-but complete the spectrum of useful queries.
+The other two queries, `uid` and `oid`, don't offer much convenience, but
+complete the spectrum of useful queries.
 
 ```text
 $ signat uid 1032668

--- a/ocfweb/docs/docs/staff/scripts/ssh-list.md
+++ b/ocfweb/docs/docs/staff/scripts/ssh-list.md
@@ -10,8 +10,9 @@ The usage of ssh-list looks like:
 The arguments before the `--` are interpreted by `ssh-list`, and the arguments
 after are passed verbatim to `parallel-ssh`.
 
-In most cases, you want at least `-i` in the arguments to parallel-ssh. `-i` prints
-out the stdout and stderr for each host you are running the command on. For example:
+In most cases, you want at least `-i` in the arguments to parallel-ssh. `-i`
+prints out the stdout and stderr for each host you are running the command on.
+For example:
 
     ssh-list all -- -i whoami
 
@@ -22,7 +23,6 @@ If you get a ton of authentication errors, don't provide your password, just do
 
 Some useful commands are below (please add more!):
 
-
 ### Run puppet once
 
 Anyone in `ocfroot` can call `sudo puppet-trigger` without providing a
@@ -30,13 +30,11 @@ password.
 
     ssh-list desktop -- -i 'sudo puppet-trigger'
 
-
 ### Restart unused desktops
 
 Anyone in `ocfroot` can call `sudo shutdown` without providing a password.
 
     ssh-list desktop -- -i '[ $(who | wc -l) -eq 0 ] && sudo shutdown -r now'
-
 
 ### Run `apt-get update` to clear apt caches
 

--- a/ocfweb/docs/docs/staff/staffvm.md
+++ b/ocfweb/docs/docs/staff/staffvm.md
@@ -1,6 +1,7 @@
 [[!meta title="Useful staff VM tricks"]]
 
 ## Essentials
+
 Your vm's environment is determined by the ldap entry for the machine.
 ```
 johnsnow@~$ kinit johnsnow/admin ldapvi cn=whitewalker


### PR DESCRIPTION
It makes paragraphs with long URLs look kind of derpy, but this formatting is
the divine decree of vim's linewrap feature (`gq}`).

This touches a lot of files. It would be very useful for others to check for broken headers, indentation, etc.