### PR TITLE
Only add a reverse trigger on ocflib if we're master

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,13 +1,15 @@
-properties([
-    pipelineTriggers([
-        triggers: [
-            [
-                $class: 'jenkins.triggers.ReverseBuildTrigger',
-                upstreamProjects: 'ocflib-upload-pypi', threshold: hudson.model.Result.SUCCESS
+if (env.BRANCH_NAME == 'master') {
+    properties([
+        pipelineTriggers([
+            triggers: [
+                [
+                    $class: 'jenkins.triggers.ReverseBuildTrigger',
+                    upstreamProjects: 'ocflib-upload-pypi', threshold: hudson.model.Result.SUCCESS
+                ]
             ]
-        ]
-    ]),
-])
+        ]),
+    ])
+}
 
 node('slave') {
     step([$class: 'WsCleanup'])


### PR DESCRIPTION
Currently if you push to ocflib, it rebuilds every single ocfweb branch, which is probably unnecessary.