### PR TITLE
Add option to disable pages depending on create

### DIFF
--- a/ocfweb/account/chpass.py
+++ b/ocfweb/account/chpass.py
@@ -11,6 +11,7 @@ from ocfweb.account.constants import TESTER_CALNET_UIDS
 from ocfweb.auth import calnet_required
 from ocfweb.component.celery import change_password as change_password_task
 from ocfweb.component.forms import Form
+from ocfweb.component.lab_status import create_required
 
 
 CALLINK_ERROR_MSG = ("Couldn't connect to CalLink API. Resetting group "
@@ -43,6 +44,7 @@ def get_accounts_for(calnet_uid):
 
 
 @calnet_required
+@create_required
 def change_password(request):
     calnet_uid = request.session['calnet_uid']
     error = None

--- a/ocfweb/account/register.py
+++ b/ocfweb/account/register.py
@@ -20,9 +20,11 @@ from ocfweb.component.celery import celery_app
 from ocfweb.component.celery import validate_then_create_account
 from ocfweb.component.forms import Form
 from ocfweb.component.forms import wrap_validator
+from ocfweb.component.lab_status import create_required
 
 
 @calnet_required
+@create_required
 def request_account(request):
     calnet_uid = request.session['calnet_uid']
     status = 'new_request'
@@ -108,6 +110,7 @@ def request_account(request):
     )
 
 
+@create_required
 def wait_for_account(request):
     if 'approve_task_id' not in request.session:
         return render(

--- a/ocfweb/component/lab_status.py
+++ b/ocfweb/component/lab_status.py
@@ -1,27 +1,62 @@
+# TODO: rename this to some generic ocfweb config file, since it's not just for
+# lab status anymore
 from collections import namedtuple
 
 import requests
 import yaml
+from django.shortcuts import render
 
+from ocfweb.account.constants import TESTER_CALNET_UIDS
 from ocfweb.caching import periodic
 
 
-LabStatus = namedtuple('LabStatus', [
+LabStatus = namedtuple('LabStatus', (
     'force_lab_closed',
     'banner_html',
-])
+    'create_disabled',
+))
 
 
 @periodic(60, ttl=86400)
 def get_lab_status():
-    """Get the front page banner message from the default location."""
+    """Load the lab status from the default location."""
     try:
         with open('/home/s/st/staff/lab_status.yaml') as f:
-            tree = yaml.safe_load(f)
+            status = yaml.safe_load(f)
     except IOError:
-        tree = yaml.safe_load(requests.get(
-            'https://www.ocf.berkeley.edu/~staff/lab_status.yaml').text)
+        req = requests.get('https://www.ocf.berkeley.edu/~staff/lab_status.yaml')
+        assert req.status_code == 200, req.status_code
+        status = yaml.safe_load(req.text)
     return LabStatus(
-        force_lab_closed=tree['force_lab_closed'],
-        banner_html=tree['banner_html'] if tree['banner_visible'] else ''
+        force_lab_closed=status['force_lab_closed'],
+        banner_html=status.get('banner_html', ''),
+        create_disabled=status['create_disabled'],
     )
+
+
+def create_required(fn):
+    """Mark a view as requiring create.
+
+    The view will be disabled (non-staff users will get a 503) when
+    create_disabled is specified in lab_status.yaml.
+
+    The purpose of this is so that we can disable create when things are broken
+    (or when we're testing), which gives users a reasonable error. This is
+    nicer than the alternative (random 500s after they've filled out the entire
+    form).
+
+    Staff are exempted based on calnet testers.
+    """
+    def _decorator(request, *args, **kwargs):
+        lab_status = get_lab_status()
+
+        if lab_status.create_disabled:
+            calnet_uid = request.session.get('calnet_uid')
+            if calnet_uid not in TESTER_CALNET_UIDS:
+                return render(request, 'create_disabled.html', {
+                    'title': 'Page Temporarily Unavailable',
+                }, status=503)
+
+        return fn(request, *args, **kwargs)
+
+    return _decorator

--- a/ocfweb/templates/create_disabled.html
+++ b/ocfweb/templates/create_disabled.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="ocf-content-block">
+    <p>
+        Sorry, but this page is currently undergoing maintenance by our
+        volunteer staff team.
+    </p>
+    <p>
+    Please check back in a bit&mdash;we'll try to be quick! If for some reason
+    you need to contact us, you can <a href="{% url 'doc' 'contact' %}">do that
+    here</a>.
+    </p>
+</div>
+{% endblock %}

--- a/ocfweb/templates/group_accounts_only.html
+++ b/ocfweb/templates/group_accounts_only.html
@@ -1,7 +1,5 @@
 {% extends "base.html" %}
 
-{% block title %}Group Accounts Only{% endblock %}
-
 {% block content %}
 
 <p>The page you tried to request is only available for group accounts. You are currently logged in as <strong>{{ user }}</strong>, which we believe is an individual OCF account.</p>


### PR DESCRIPTION
This lets us turn off create based on a config option if create is broken for some reason.

Obviously we want to minimize this time, but it's useful when testing changes to create, since we can make sure users won't get a broken experience.