### PR TITLE
Update venv-update to 2.0.0

### DIFF
--- a/vendor/venv-update
+++ b/vendor/venv-update
@@ -57,8 +57,9 @@ from __future__ import unicode_literals
 
 from os.path import exists
 from os.path import join
+from subprocess import CalledProcessError
 
-__version__ = '1.1.2'
+__version__ = '2.0.0'
 DEFAULT_VIRTUALENV_PATH = 'venv'
 DEFAULT_OPTION_VALUES = {
     'venv=': (DEFAULT_VIRTUALENV_PATH,),
@@ -141,7 +142,7 @@ def info(msg):
 
 
 def check_output(cmd):
-    from subprocess import Popen, PIPE, CalledProcessError
+    from subprocess import Popen, PIPE
     process = Popen(cmd, stdout=PIPE)
     output, _ = process.communicate()
     if process.returncode:
@@ -205,7 +206,10 @@ def exec_scratch_virtualenv(args):
         rename(tmp, scratch.src)
 
     import sys
-    if sys.prefix != scratch.venv:
+    from os.path import realpath
+    # We want to compare the paths themselves as sometimes sys.path is the same
+    # as scratch.venv, but with a suffix of bin/..
+    if realpath(sys.prefix) != realpath(scratch.venv):
         # TODO-TEST: sometimes we would get a stale version of venv-update
         exec_((scratch.python, dotpy(__file__)) + args)  # never returns
 
@@ -248,7 +252,10 @@ def get_python_version(interpreter):
 
 
 def invalid_virtualenv_reason(venv_path, source_python, destination_python, options):
-    orig_path = get_original_path(venv_path)
+    try:
+        orig_path = get_original_path(venv_path)
+    except CalledProcessError:
+        return 'could not inspect metadata'
     if not samefile(orig_path, venv_path):
         return 'virtualenv moved %s -> %s' % (timid_relpath(orig_path), timid_relpath(venv_path))
     elif has_system_site_packages(destination_python) != options.system_site_packages:
@@ -360,21 +367,6 @@ def user_cache_dir():
     return getenv('XDG_CACHE_HOME', expanduser('~/.cache'))
 
 
-class CacheOpts(object):
-
-    def __init__(self):
-        # We put the cache in the directory that pip already uses.
-        # This has better security characteristics than a machine-wide cache, and is a
-        #   pattern people can use for open-source projects
-        self.pipdir = user_cache_dir() + '/pip-faster'
-        # We could combine these caches to one directory, but pip would search everything twice, going slower.
-        self.wheelhouse = self.pipdir + '/wheelhouse'
-
-        self.pip_options = (
-            '--find-links=file://' + self.wheelhouse,
-        )
-
-
 def venv_update(
         venv=DEFAULT_OPTION_VALUES['venv='],
         install=DEFAULT_OPTION_VALUES['install='],
@@ -422,16 +414,13 @@ def pip_faster(venv_path, pip_command, install, bootstrap_deps):
     # we always have to run the bootstrap, because the presense of an
     # executable doesn't imply the right version. pip is able to validate the
     # version in the fastpath case quickly anyway.
-    bootstrap_command = ('pip', 'install') + CacheOpts().pip_options
-    bootstrap_command += bootstrap_deps
-    run(bootstrap_command)
+    run(('pip', 'install') + bootstrap_deps)
 
     run(pip_command + install)
 
 
 def raise_on_failure(mainfunc):
     """raise if and only if mainfunc fails"""
-    from subprocess import CalledProcessError
     try:
         errors = mainfunc()
         if errors:


### PR DESCRIPTION
This fixes a bunch of issues like the concurrent cache miss bug that we sometimes hit on Jenkins.

Most of the changes are not in the vendored file but are in the venv-update package downloaded from PyPI, so this diff isn't very interesting.