### PR TITLE
add anchors to server rows

### DIFF
--- a/ocfweb/docs/templates/docs/partials/host.html
+++ b/ocfweb/docs/templates/docs/partials/host.html
@@ -3,10 +3,11 @@
 
 <div class="row host host-{{host.type}}">
     <div class="col-sm-3">
-        <a id="{{host.hostname}}" class="server-anchor"></a>
-        <p class="hostname">{{host.hostname}}</p>
-        <p class="ip">{{host.ipv4}}</p>
-        <p class="ip">{{host.ipv6}}</p>
+      <a id="{{host.hostname}}" class="server-anchor" href="#{{host.hostname}}">
+    <p class="hostname">{{host.hostname}}</p>
+      </a>
+      <p class="ip">{{host.ipv4}}</p>
+      <p class="ip">{{host.ipv6}}</p>
     </div>
     <div class="col-sm-2">
         <p class="type">{{host.english_type}}</p>

--- a/ocfweb/docs/templates/docs/partials/host.html
+++ b/ocfweb/docs/templates/docs/partials/host.html
@@ -3,7 +3,7 @@
 
 <div class="row host host-{{host.type}}">
     <div class="col-sm-3">
-        <a name="{{host.hostname}}" class="server-anchor"></a>
+        <a id="{{host.hostname}}" class="server-anchor"></a>
         <p class="hostname">{{host.hostname}}</p>
         <p class="ip">{{host.ipv4}}</p>
         <p class="ip">{{host.ipv6}}</p>

--- a/ocfweb/docs/templates/docs/partials/host.html
+++ b/ocfweb/docs/templates/docs/partials/host.html
@@ -4,7 +4,7 @@
 <div class="row host host-{{host.type}}">
     <div class="col-sm-3">
       <a id="{{host.hostname}}" class="server-anchor" href="#{{host.hostname}}">
-    <p class="hostname">{{host.hostname}}</p>
+          <p class="hostname">{{host.hostname}}</p>
       </a>
       <p class="ip">{{host.ipv4}}</p>
       <p class="ip">{{host.ipv6}}</p>

--- a/ocfweb/docs/templates/docs/partials/host.html
+++ b/ocfweb/docs/templates/docs/partials/host.html
@@ -3,6 +3,7 @@
 
 <div class="row host host-{{host.type}}">
     <div class="col-sm-3">
+        <a name="{{host.hostname}}" class="server-anchor"></a>
         <p class="hostname">{{host.hostname}}</p>
         <p class="ip">{{host.ipv4}}</p>
         <p class="ip">{{host.ipv6}}</p>

--- a/ocfweb/static/scss/pages/docs/_servers.scss
+++ b/ocfweb/static/scss/pages/docs/_servers.scss
@@ -71,10 +71,12 @@
             }
 
             .server-anchor {
-                display: block;
-                position: relative;
-                top: -75px;
-                visibility: hidden;
+                &:before {
+                    content: '';
+                    display: block;
+                    height: 60px;
+                    margin-top: -60px;
+                }
             }
         }
     }

--- a/ocfweb/static/scss/pages/docs/_servers.scss
+++ b/ocfweb/static/scss/pages/docs/_servers.scss
@@ -69,6 +69,13 @@
                     }
                 }
             }
+
+            .server-anchor {
+                display: block;
+                position: relative;
+                top: -75px;
+                visibility: hidden;
+            }
         }
     }
 }


### PR DESCRIPTION
I found myself often going to /docs/backend/servers/ to recall which VM corresponded to which task, this just adds a nice jump directly to the server name. For example, 

http://nyx.ocf.berkeley.edu:8934/docs/staff/backend/servers/#supernova