### PR TITLE
Upgrade to celery 4, use stunnel instead of spiped

### DIFF
--- a/ocfweb/component/celery.py
+++ b/ocfweb/component/celery.py
@@ -4,6 +4,8 @@ This module is responsible for instantiating the Celery tasks used for account
 creation using our special credentials. Other modules should import from here,
 rather than from ocflib directly.
 """
+import ssl
+
 from celery import Celery
 from django.conf import settings
 from ocflib.account.submission import get_tasks as real_get_tasks
@@ -12,6 +14,21 @@ celery_app = Celery(
     broker=settings.CELERY_BROKER,
     backend=settings.CELERY_BACKEND,
 )
+# TODO: use ssl verification
+celery_app.conf.broker_use_ssl = {
+    'ssl_cert_reqs': ssl.CERT_NONE,
+}
+# `redis_backend_use_ssl` is an OCF patch which was proposed upstream:
+# https://github.com/celery/celery/pull/3831
+celery_app.conf.redis_backend_use_ssl = {
+    'ssl_cert_reqs': ssl.CERT_NONE,
+}
+
+# TODO: stop using pickle
+celery_app.conf.task_serializer = 'pickle'
+celery_app.conf.result_serializer = 'pickle'
+celery_app.conf.accept_content = {'pickle'}
+
 _tasks = real_get_tasks(celery_app)
 
 create_account = _tasks.create_account

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -1,5 +1,7 @@
 cached-property
-celery[redis]<3.999
+# TODO: stop using our fork
+# https://github.com/celery/celery/pull/3831
+ckuehl-celery[redis]==4.0.2.post1
 django-bootstrap-form
 django-ipware
 django-mathfilters

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -13,6 +13,8 @@ matplotlib
 mistune
 numpy
 ocflib
+# TODO: pysnmp==4.3.2 can't work with newer pyasn1; one we upgrade, delete this
+pyasn1==0.1.9
 pycrypto
 pygments
 pymysql

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ paramiko==2.1.1
 pexpect==4.2.1
 ply==3.10
 ptyprocess==0.5.1
-pyasn1==0.2.2
+pyasn1==0.1.9
 pycparser==2.17
 pycrypto==2.6.1
 Pygments==2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,9 @@
-amqp==1.4.9
-anyjson==0.3.3
+amqp==2.1.4
 appdirs==1.4.0
-billiard==3.3.0.23
+billiard==3.5.0.2
 cached-property==1.3.0
-celery==3.1.25
 cffi==1.9.1
+ckuehl-celery==4.0.2.post1
 cracklib==2.9.3
 cryptography==1.7.2
 cycler==0.10.0
@@ -14,11 +13,10 @@ django-ipware==1.1.6
 django-mathfilters==0.4.0
 django-redis==4.7.0
 dnspython==1.15.0
-dnspython3==1.15.0
 gunicorn==19.6.0
 idna==2.2
 Jinja2==2.9.5
-kombu==3.0.37
+kombu==4.0.2
 ldap3==2.2.0
 libsass==0.12.3
 MarkupSafe==0.23
@@ -34,12 +32,11 @@ ptyprocess==0.5.1
 pyasn1==0.2.2
 pycparser==2.17
 pycrypto==2.6.1
-pycryptodome==3.4.5
 Pygments==2.2.0
 PyMySQL==0.7.9
 pyparsing==2.1.10
 pysmi==0.0.7
-pysnmp==4.3.3
+pysnmp==4.3.2
 python-dateutil==2.6.0
 pytz==2016.10
 PyYAML==3.12
@@ -48,3 +45,4 @@ requests==2.13.0
 setuptools==34.1.1
 six==1.10.0
 SQLAlchemy==1.1.5
+vine==1.1.3


### PR DESCRIPTION
~~still using spiped for redis locking~~ that doesn't actually happen in ocfweb anyway