### PR TITLE
Stop using my pre-commit fork

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
--   repo: https://github.com/chriskuehl/pre-commit-hooks.git
-    sha: cd3f867cafee3488a93a13f97bf7fdab329c996e
+-   repo: https://github.com/pre-commit/pre-commit-hooks.git
+    sha: v0.7.1
     hooks:
     -   id: autopep8-wrapper
         language_version: python3
@@ -14,6 +14,7 @@
     -   id: debug-statements
         language_version: python3
     -   id: detect-private-key
+        exclude: ^(ocfweb/static/scss/bootstrap|bootstrap-scss|docs)$
     -   id: double-quote-string-fixer
         language_version: python3
     -   id: end-of-file-fixer
@@ -25,16 +26,16 @@
     -   id: requirements-txt-fixer
     -   id: trailing-whitespace
         exclude: ^ocfweb/static/fonts/bootstrap/
--   repo: https://github.com/chriskuehl/reorder_python_imports.git
-    sha: 138f897f7d53c53dd4535dc377764fa3a58e310c
+-   repo: https://github.com/asottile/reorder_python_imports.git
+    sha: v0.3.1
     hooks:
     -   id: reorder-python-imports
         language_version: python3
--   repo: https://github.com/chriskuehl/pre-commit-hooks-1.git
-    sha: cb3b03ba29a70be8ff4702429ea331cfc61b87c8
+-   repo: https://github.com/Lucas-C/pre-commit-hooks.git
+    sha: v1.0.1
     hooks:
     -   id: remove-tabs
-        exclude: ^Makefile$
+        exclude: ^(Makefile|ocfweb/static/scss/bootstrap|bootstrap-scss|docs)$
         language_version: python2.7
 -   repo: https://github.com/pre-commit/mirrors-scss-lint
     sha: v0.52.0
@@ -46,7 +47,7 @@
         language: pcre
         name: No top-level headers (markdown)
         entry: ^#\s
-        types: [markdown]
+        files: \.md$
     # In Django, if you have an app like "announcements" and another app like
     # "docs", it's not okay for both to provide templates with the same name
     # (e.g. "index.html") since they all get thrown onto the same templates

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,10 @@ dev: venv ocfweb/static/scss/site.scss.css
 venv: requirements.txt requirements-dev.txt
 	python ./vendor/venv-update venv= venv -ppython3 install= -r requirements.txt -r requirements-dev.txt
 
+.PHONY: install-hooks
+install-hooks: venv
+	$(BIN)/pre-commit install -f --install-hooks
+
 .PHONY: clean
 clean:
 	rm -rf *.egg-info venv

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ We use [pre-commit](http://pre-commit.com/) to lint our code before commiting.
 While some of the rules might seem a little arbitrary, it helps keep the style
 consistent, and ensure annoying things like trailing whitespace don't creep in.
 
-You can simply run `pre-commit install` to install the necessary git hooks;
+You can simply run `make install-hooks` to install the necessary git hooks;
 once installed, pre-commit will run every time you commit.
 
 Alternatively, if you'd rather not install any hooks, you can simply use `make

--- a/ocfweb/docs/docs/staff/staffvm.md
+++ b/ocfweb/docs/docs/staff/staffvm.md
@@ -3,18 +3,17 @@
 ## Essentials
 
 Your vm's environment is determined by the ldap entry for the machine.
-```
-johnsnow@~$ kinit johnsnow/admin ldapvi cn=whitewalker
-### ...LDIF
-#...
-# whitewalker, Hosts, OCF.Berkeley.EDU
-dn: cn=whitewalker,ou=Hosts,dc=OCF,dc=Berkeley,dc=EDU
-objectClass: device
-objectClass: ocfDevice
-cn: whitewalker
-ipHostNumber: 169.229.226.256
-type: server
-puppetVar: owner=johnsnow
-environment: johnsnow
-#...
-```
+
+    johnsnow@~$ kinit johnsnow/admin ldapvi cn=whitewalker
+    ### ...LDIF
+    #...
+    # whitewalker, Hosts, OCF.Berkeley.EDU
+    dn: cn=whitewalker,ou=Hosts,dc=OCF,dc=Berkeley,dc=EDU
+    objectClass: device
+    objectClass: ocfDevice
+    cn: whitewalker
+    ipHostNumber: 169.229.226.256
+    type: server
+    puppetVar: owner=johnsnow
+    environment: johnsnow
+    #...

--- a/requirements-dev-minimal.txt
+++ b/requirements-dev-minimal.txt
@@ -1,8 +1,8 @@
-ckuehl-pre-commit-types==0.7.6.dev1
 coverage
 coveralls
 ipdb
 mock
+pre-commit
 pytest
 pytest-django
 requirements-tools

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,4 @@
-argparse==1.4.0
 aspy.yaml==0.2.2
-ckuehl-pre-commit-types==0.7.6.dev1
 coverage==4.3.4
 coveralls==1.1
 decorator==4.0.11
@@ -11,9 +9,9 @@ ipython-genutils==0.1.0
 jsonschema==2.6.0
 mock==2.0.0
 nodeenv==1.1.2
-ordereddict==1.1
 pbr==1.10.0
 pickleshare==0.7.4
+pre-commit==0.13.2
 prompt-toolkit==1.0.13
 py==1.4.32
 pytest==3.0.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ gunicorn==19.6.0
 idna==2.2
 Jinja2==2.9.5
 kombu==4.0.2
-ldap3==2.2.0
+ldap3==2.2.1
 libsass==0.12.3
 MarkupSafe==0.23
 matplotlib==2.0.0
@@ -33,7 +33,7 @@ pyasn1==0.1.9
 pycparser==2.17
 pycrypto==2.6.1
 Pygments==2.2.0
-PyMySQL==0.7.9
+PyMySQL==0.7.10
 pyparsing==2.1.10
 pysmi==0.0.7
 pysnmp==4.3.2
@@ -42,7 +42,7 @@ pytz==2016.10
 PyYAML==3.12
 redis==2.10.5
 requests==2.13.0
-setuptools==34.1.1
+setuptools==34.2.0
 six==1.10.0
 SQLAlchemy==1.1.5
 vine==1.1.3


### PR DESCRIPTION
We don't need it for ocfweb (utils and puppet are the only repos that
need it).