### PR TITLE
Semester job

### DIFF
--- a/ocfweb/stats/job_frequency.py
+++ b/ocfweb/stats/job_frequency.py
@@ -81,11 +81,12 @@ def get_jobs_plot(day):
 
     tickLocations = np.arange(1, day_quota + 1)
     width = 0.8
-    ax.bar(tickLocations, today_jobs_count, width, color='blue')
+    ax.bar(tickLocations, today_jobs_count, width)
 
     ax.set_xticks(ticks=tickLocations)
     ax.yaxis.set_major_locator(MaxNLocator(integer=True))
     ax.yaxis.grid(True)
+    ax.set_ylim(ymin=0)
     ax.set_ylabel('Number of Jobs Printed')
     ax.set_title('Print Job Distribution {:%a %b %d}'.format(day))
 

--- a/ocfweb/stats/semester_job.py
+++ b/ocfweb/stats/semester_job.py
@@ -1,0 +1,89 @@
+import ocflib.printing.quota as quota
+from django.http import HttpResponse
+from matplotlib.figure import Figure
+from matplotlib.ticker import MaxNLocator
+from ocflib.lab.stats import semester_dates
+from ocflib.printing.quota import WEEKDAY_QUOTA
+from ocflib.printing.quota import WEEKEND_QUOTA
+
+from ocfweb.component.graph import canonical_graph
+from ocfweb.component.graph import plot_to_image_bytes
+
+
+@canonical_graph(default_start_end=semester_dates)
+def weekday_jobs_image(request, start_day, end_day):
+    return HttpResponse(
+        plot_to_image_bytes(get_jobs_plot('weekday', start_day, end_day), format='svg'),
+        content_type='image/svg+xml',
+    )
+
+
+@canonical_graph(default_start_end=semester_dates)
+def weekend_jobs_image(request, start_day, end_day):
+    return HttpResponse(
+        plot_to_image_bytes(get_jobs_plot('weekend', start_day, end_day), format='svg'),
+        content_type='image/svg+xml',
+    )
+
+
+# dictionary that gives parameters/config of different job graphs
+graphs = {
+    'weekday':
+        {'query': '''
+                SELECT `pages`, SUM(`count`) AS `count`
+                FROM `public_jobs`
+                WHERE
+                    (`pages` <= %s) AND
+                    (DAYOFWEEK(`day`) MOD 7 > 1) AND
+                    (`day` BETWEEN CAST(%s AS Date) AND CAST(%s AS DATE))
+                GROUP BY `pages`''',
+         'quota': tuple([WEEKDAY_QUOTA]),
+         'title': 'Semester Weekday Jobs Distributiom'},
+    'weekend':
+        {'query': '''
+                SELECT `pages`, SUM(`count`) AS `count`
+                FROM `public_jobs`
+                WHERE
+                    (`pages` <= %s) AND
+                    (DAYOFWEEK(`day`) MOD 7 <= 1) AND
+                    (`day` BETWEEN CAST(%s AS Date) AND CAST(%s AS DATE))
+                GROUP BY `pages`''',
+         'quota': tuple([WEEKEND_QUOTA]),
+         'title': 'Semester Weekend Jobs Distribution'}
+}
+
+
+def freq_plot(data, title,
+              ylab='Number of Jobs Printed'):
+    """takes in data, title, and ylab and makes a histogram, with
+    the 1:len(data) as the xaxis
+    """
+    fig = Figure(figsize=(10, 4))
+    ax = fig.add_subplot(1, 1, 1)
+
+    tickLocations = range(1, len(data) + 1)
+    width = 0.8
+    ax.bar(tickLocations, data, width)
+
+    ax.set_xticks(ticks=tickLocations)
+    ax.yaxis.set_major_locator(MaxNLocator(integer=True))
+    ax.yaxis.grid(True)
+    ax.set_ylim(ymin=0)
+    ax.set_ylabel(ylab)
+    ax.set_title(title)
+
+    return fig
+
+
+def get_jobs_plot(graph, start_day, end_day):
+    """Return matplotlib plot of the number of jobs of different page-jobs"""
+    graph_config = graphs[graph]
+    with quota.get_connection() as cursor:
+        cursor.execute(graph_config['query'],
+                       graph_config['quota'] + (start_day, end_day))
+        data = cursor.fetchall()
+
+    jobs_dict = {row['pages']: row['count'] for row in data}
+    jobs_count = [jobs_dict.get(i, 0) for i in range(1, graph_config['quota'][0] + 1)]
+
+    return freq_plot(jobs_count, graph_config['title'])

--- a/ocfweb/stats/templates/stats/printing.html
+++ b/ocfweb/stats/templates/stats/printing.html
@@ -7,6 +7,8 @@
         {% stats_navbar %}
         <p>
             <img class="img-responsive" src="{% url 'daily_job_image' %}" />
+            <img class="img-responsive" src="{% url 'weekday_jobs_image' %}" />
+            <img class="img-responsive" src="{% url 'weekend_jobs_image' %}" />
             <img class="img-responsive" src="{% url 'semester_histogram' %}" />
         </p>
 

--- a/ocfweb/stats/urls.py
+++ b/ocfweb/stats/urls.py
@@ -8,6 +8,8 @@ from ocfweb.stats.job_frequency import daily_jobs_image
 from ocfweb.stats.printing import pages_printed
 from ocfweb.stats.printing import semester_histogram
 from ocfweb.stats.printing import stats_printing
+from ocfweb.stats.semester_job import weekday_jobs_image
+from ocfweb.stats.semester_job import weekend_jobs_image
 from ocfweb.stats.session_count import session_count_image
 from ocfweb.stats.session_length import session_length_image
 from ocfweb.stats.summary import summary
@@ -28,4 +30,6 @@ urlpatterns = [
     url(r'^printing/semester-histogram/graph$', semester_histogram, name='semester_histogram'),
     url(r'^printing/pages-printed$', pages_printed, name='pages_printed'),
     url(r'^printing/daily-job/graph$', daily_jobs_image, name='daily_job_image'),
+    url(r'^printing/weekend-jobs/graph$', weekend_jobs_image, name='weekend_jobs_image'),
+    url(r'^printing/weekday-jobs/graph$', weekday_jobs_image, name='weekday_jobs_image'),
 ]


### PR DESCRIPTION
Adding semester-wise weekday/weekend job distribution graphs. You can also adjust adjust the start and end date of the url request to adjust to time interval that is being queried. 

Suggestions on graph locations/titles/labels and Code Reviews?
(also it is possible to use the code from semester_job.py to create daily job graph by making some changes not sure if you guys want it or not)
http://supernova:8977/stats/printing/