### PR TITLE
remove unnecessary h_ tag in html ids/quicklinks

### DIFF
--- a/ocfweb/component/markdown.py
+++ b/ocfweb/component/markdown.py
@@ -108,7 +108,7 @@ class HeaderRendererMixin:
     """Mixin to render headers with auto-generated IDs (or provided IDs).
 
     If headers are written as usual, they'll be given automatically-generated
-    IDs based on their header level and text.
+    IDs based on their text.
 
     Headers can also be specified with an ID at the end wrapped in curly braces:
 
@@ -139,10 +139,7 @@ class HeaderRendererMixin:
             if id in self.toc_ids:
                 raise ValueError('Duplicate header ID in Markdown: "{}"'.format(id))
         else:
-            id = 'h{level}_{title}'.format(
-                level=level,
-                title=re.sub('[^a-z0-9\-_ ]', '', strip_tags(text).lower()).strip().replace(' ', '-'),
-            )
+            id = re.sub('[^a-z0-9\-_ ]', '', strip_tags(text).lower()).strip().replace(' ', '-')
 
             # dumb collision avoidance
             while id in self.toc_ids:

--- a/ocfweb/docs/docs/services/vhost.md
+++ b/ocfweb/docs/docs/services/vhost.md
@@ -42,7 +42,7 @@ of the virtual-hosted site (`yourgroup.berkeley.edu`).
      form|request_vhost]] online. OCF staff will review your request and
      contact the university hostmaster on your behalf.
 
-### Including the OCF banner
+### Including the OCF banner    {banner}
 
 Place any of the [[Hosted by OCF banners|doc services/vhost/badges]] on your
 site by copying the code onto your page. The banner is required to be placed
@@ -78,7 +78,7 @@ domain. For such domains, the group account must:
  2.   Pay any and all fees and/or obtain permissions relating to obtaining and
       maintaining a domain name.
 
-#### University policies
+#### University policies    {university-policies}
 
 Virtual web sites, just like other OCF user accounts, must comply with the
 relevant UC Berkeley [computer use policy][computer-use] and [DNS
@@ -104,7 +104,7 @@ In particular,
 
 [offsite]: https://offsitehosting.berkeley.edu/
 
-#### Hosting badge
+#### Hosting badge    {badge}
 
 All virtual hosts on the OCF must include an [[OCF banner|doc
 services/vhost/badges]] on the front page that links to the [[OCF home

--- a/ocfweb/docs/docs/services/web/backups.md
+++ b/ocfweb/docs/docs/services/web/backups.md
@@ -14,7 +14,7 @@ following the examples on this page. You could alternatively use SFTP, but this
 wouldn't allow you to back up a database.
 
 
-## Backing up a web directory
+## Backing up a web directory    {web}
 
 Making a backup of your website document tree (where all the `.html`, `.php`,
 etc. files are) is as simple as making a copy of your files into your home
@@ -41,7 +41,7 @@ Instead, explicitly copy all the files inside to another directory or use the
 the commands on this page which were written to do so.
 
 
-## Backing up a database
+## Backing up a database    {database}
 
 For many websites and frameworks, the web document tree only makes up half the
 site; the rest of the data resides in the database. Particularly, if you are
@@ -99,7 +99,7 @@ However, you would need to run `makemysql` to create a new database, which
 would permanently change your password.
 
 
-## Example backup
+## Example backup    {example}
 
 Suppose your OCF account name is `johndoe` and you have WordPress installed
 directly in `~/public_html`. A typical backup might look like this:
@@ -118,7 +118,7 @@ If you were using `.my.cnf`, you wouldn't even have to enter your database
 password.
 
 
-## Security
+## Security     {security}
 
 The only real security concern is that you don't leave any backup files in your
 `public_html` directory. Doing so would allow anybody to download all your raw

--- a/ocfweb/docs/docs/services/web/django.md
+++ b/ocfweb/docs/docs/services/web/django.md
@@ -3,7 +3,7 @@
 Django is a popular web framework for Python applications.
 
 
-## Starting a Django project
+## Starting a Django project    {starting}
 
 The necessary scripts for you to create Django projects are installed on our
 login server, _ssh.ocf.berkeley.edu_.

--- a/ocfweb/docs/docs/services/web/flask.md
+++ b/ocfweb/docs/docs/services/web/flask.md
@@ -4,7 +4,7 @@ Flask is a popular microframework for Python web development. Using it on the
 OCF servers requires only just a little extra configuration.
 
 
-## Starting a Flask project
+## Starting a Flask project    {starting}
 
 1.    Make a directory in your ~/public_html directory:
 

--- a/ocfweb/docs/docs/services/web/php.md
+++ b/ocfweb/docs/docs/services/web/php.md
@@ -12,7 +12,7 @@ non-standard packages installed:
 
 For a full list of available modules, run `phpinfo()` from a PHP script.
 
-## Custom PHP settings
+## Custom PHP settings    {custom-settings}
 
 If the default PHP settings are problematic for your site (for example, if you
 require larger than normal file uploads), you can customize the PHP settings
@@ -26,7 +26,7 @@ and add only the settings you wish to change.
 Note that `.user.ini` filename should be used, as our webserver will not look
 for (per-user) `php.ini` files.
 
-### Example `.user.ini` file
+### Example `.user.ini` file     {example}
 
 The following file, located at `~/public_html/.user.ini`, is an example of a
 good `.user.ini` file.

--- a/ocfweb/docs/docs/services/web/rails.md
+++ b/ocfweb/docs/docs/services/web/rails.md
@@ -3,7 +3,7 @@
 
 Ruby on Rails is a popular web framework for Ruby applications.
 
-## Creating a New Application
+## Creating a New Application    {new}
 
 To create a new Rails application, use the `rails` command-line interface. For
 example, to create an application called `foo` in your home directory, run the
@@ -13,7 +13,7 @@ command:
 
 This may take some time.
 
-## Hosting Your Application
+## Hosting Your Application     {hosting}
 
 OCF allows hosting of Rails applications via FastCGI. This requires you to
 install the `fcgi` gem and create a FastCGI wrapper script.
@@ -26,7 +26,7 @@ install the `fcgi` gem and create a FastCGI wrapper script.
 2. Run `bundle install` from the root of your project to update installed gems.
    This will ensure that the `fcgi` gem is installed.
 
-### Create FastCGI wrapper script
+### Create FastCGI wrapper script     {fastcgi}
 
 To host your application, create a file called `dispatch.fcgi` in your web root
 (`~/public_html/`) based on the following template:
@@ -78,7 +78,7 @@ containing the following lines:
 
 Be sure to replace `user` with your username.
 
-### Debugging
+### Debugging     {debugging}
 
 If you see an error page when trying to load your app, you may find the
 webserver's logs useful. You can access them via SSH in the following

--- a/ocfweb/docs/docs/services/web/wordpress.md
+++ b/ocfweb/docs/docs/services/web/wordpress.md
@@ -10,7 +10,7 @@ Instructions for using WordPress are provided below; you can also [[drop by
 during staff hours|staff-hours]] for in-person assistance.
 
 
-## Installing WordPress
+## Installing WordPress    {installing}
 
 The easiest way to set up WordPress is via [[SSH|doc services/shell]]. Some
 simple instructions:
@@ -51,7 +51,7 @@ Your WordPress installation is now ready! You can log in using the username and
 password you created and start configuring your site.
 
 
-## Migrating from WordPress.com to OCF
+## Migrating from WordPress.com to OCF     {migrating}
 
 If you already have a site hosted at WordPress.com and you'd like to move it to
 OCF web hosting, for example, to become eligible for [[virtual hosting|doc
@@ -94,9 +94,9 @@ Further details can be found at [the support page by WordPress.com][1].
 [1]: https://en.support.wordpress.com/moving-to-a-self-hosted-wordpress-site/
 
 
-## Frequently Asked Questions
+## Frequently Asked Questions    {faq}
 
-### Jetpack plugin not working
+### Jetpack plugin not working     {jetpack}
 
 The Jetpack plugin as well as several others require a publicly accessible
 XML-RPC file, which is not public by default. Before you can install Jetpack,
@@ -113,7 +113,7 @@ folder:
 If `.htaccess` doesn't exist, create it and add the above lines.
 
 
-### I forgot my admin password and can't log in
+### I forgot my admin password and can't log in     {forgot-pwd}
 
 First, try using the "Forgot Password" feature on your site. You can find a
 link from the login page.
@@ -156,7 +156,7 @@ hours|staff-hours]] instead.
    `new_password` with your new password.)
 
 
-### I forgot my MySQL (database) password
+### I forgot my MySQL (database) password    {forgot-db-pwd}
 
 The database password used by WordPress is recorded in the WordPress
 configuration file `wp-config.php` on the line that looks like
@@ -174,7 +174,7 @@ cat ~/path/to/wordpress/wp-config.php | grep DB_PASSWORD
 ```
 
 
-### My site URL is configured incorrectly
+### My site URL is configured incorrectly    {site-url}
 
 If your site URL is configured incorrectly, you may have issues such as being
 unable to log in or being caught in a redirect loop.

--- a/ocfweb/docs/docs/staff/docs.md
+++ b/ocfweb/docs/docs/staff/docs.md
@@ -11,7 +11,7 @@ Markdown syntax is parsed by [Mistune][mistune] with syntax highlighting done
 by [Pygments][pygments].
 
 We use a wiki-like syntax for making links within documentation and the
-website, e.g. from [[Virtual Hosting|doc services/vhost#h4_hosting-badge]]:
+website, e.g. from [[Virtual Hosting|doc services/vhost#hosting-badge]]:
 
     All virtual hosts on the OCF must include an [[OCF banner|doc services/vhost/badges]] on the front page that links to the [[OCF home page|home]].
 

--- a/tests/component/markdown_test.py
+++ b/tests/component/markdown_test.py
@@ -28,7 +28,7 @@ def test_simple_markdown():
             * bullet 2
         ''',
         '''\
-            <h1 id="h1_this-is-an-h1">this is an h1 <a class="anchor" href="#h1_this-is-an-h1"><span></span></a></h1>
+            <h1 id="this-is-an-h1">this is an h1 <a class="anchor" href="#this-is-an-h1"><span></span></a></h1>
             <p>this is some paragraph text</p>
             <ul>
             <li>bullet</li>
@@ -100,7 +100,7 @@ def test_header_default_id():
             # this is an h1
         ''',
         '''\
-            <h1 id="h1_this-is-an-h1">this is an h1 <a class="anchor" href="#h1_this-is-an-h1"><span></span></a></h1>
+            <h1 id="this-is-an-h1">this is an h1 <a class="anchor" href="#this-is-an-h1"><span></span></a></h1>
         '''
     )
 
@@ -123,8 +123,8 @@ def test_header_with_collision_automatic():
             # this is an h1
         ''',
         '''\
-            <h1 id="h1_this-is-an-h1">this is an h1 <a class="anchor" href="#h1_this-is-an-h1"><span></span></a></h1>
-            <h1 id="h1_this-is-an-h1_">this is an h1 <a class="anchor" href="#h1_this-is-an-h1_"><span></span></a></h1>
+            <h1 id="this-is-an-h1">this is an h1 <a class="anchor" href="#this-is-an-h1"><span></span></a></h1>
+            <h1 id="this-is-an-h1_">this is an h1 <a class="anchor" href="#this-is-an-h1_"><span></span></a></h1>
         '''
     )
 


### PR DESCRIPTION
With the previous formatting, linking to sections in our docs gives things like this: "https://www.ocf.berkeley.edu/docs/services/vhost/#h4_university-policies". This would make it so links now look like this "https://www.ocf.berkeley.edu/docs/services/vhost/#university-policies" which IMHO is cleaner.