### PR TITLE
Add hiring announcement

### DIFF
--- a/ocfweb/announcements/announcements.py
+++ b/ocfweb/announcements/announcements.py
@@ -127,3 +127,18 @@ def hpc_survey(title, request):
             'title': title,
         },
     )
+
+
+@announcement(
+    'The OCF is hiring!',
+    date(2017, 3, 20),
+    'hiring',
+)
+def hpc_survey(title, request):
+    return render(
+        request,
+        'announcements/2017-03-20-hiring.html',
+        {
+            'title': title,
+        },
+    )

--- a/ocfweb/announcements/announcements.py
+++ b/ocfweb/announcements/announcements.py
@@ -53,7 +53,11 @@ def index(request):
         {
             'title': 'News from the staff team',
 
-            'announcements': announcements,
+            'announcements': sorted(
+                announcements,
+                key=lambda announcement: announcement.date,
+                reverse=True
+            ),
             'blog_posts': get_blog_posts()[:10],
         },
     )

--- a/ocfweb/announcements/announcements.py
+++ b/ocfweb/announcements/announcements.py
@@ -134,7 +134,7 @@ def hpc_survey(title, request):
     date(2017, 3, 20),
     'hiring',
 )
-def hpc_survey(title, request):
+def hiring(title, request):
     return render(
         request,
         'announcements/2017-03-20-hiring.html',

--- a/ocfweb/announcements/templates/announcements/2017-03-01-hpc-survey.html
+++ b/ocfweb/announcements/templates/announcements/2017-03-01-hpc-survey.html
@@ -49,8 +49,8 @@
               interesting to you, please let us know in your response.
             </p>
             <p>
-              If you have any questions, don't hesitate to <a href="{% url
-              'doc' 'contact' %}">contact us</a>!
+              If you have any questions, don't hesitate to
+              <a href="{% url 'doc' 'contact' %}">contact us</a>!
             </p>
         </div>
     </div>

--- a/ocfweb/announcements/templates/announcements/2017-03-20-hiring.html
+++ b/ocfweb/announcements/templates/announcements/2017-03-20-hiring.html
@@ -42,9 +42,7 @@
                         and the other Operations Assistants</li>
                 </ul>
 
-                This job position will be paid $13.75 per hour, but will also
-                have less responsibilities and be more flexible than the
-                Operations Manager position. See the
+                This job position will be paid $13.75 per hour. See the
                 <a href="https://docs.google.com/document/d/1oS3ma415LbtuyeEuuoucWKYLcWOJaWmzhv2nIs5f718/edit">full job description</a>
                 for more details.
             </p>
@@ -73,7 +71,7 @@
                 be considered.
             </p>
             <p>
-                We will let you know if you have been selected for a 30 minute
+                We will let you know if you have been selected for a 20 minute
                 interview by April 9th, and the interviews will be held
                 starting April 11th and going through April 14th.
             </p>
@@ -88,7 +86,7 @@
             <h3>About the OCF</h3>
             <p>
                 The OCF provides free computing services for any students,
-                faculty, or staff that lacks access to the resources they need.
+                faculty, or staff that lack access to the resources they need.
                 Since its founding in 1989, the services offered by the OCF
                 have grown massively, especially in the past couple years as
                 the OCF moved to a much nicer new lab location in 171 MLK

--- a/ocfweb/announcements/templates/announcements/2017-03-20-hiring.html
+++ b/ocfweb/announcements/templates/announcements/2017-03-20-hiring.html
@@ -1,0 +1,121 @@
+{% extends 'base.html' %}
+{% load staticfiles %}
+
+{% block content %}
+    <div class="row">
+        <div class="col-sm-8 ocf-content-block">
+            <h3></h3>
+            <p><em>March 20, 2017</em></p>
+            <hr />
+            <p>
+                The OCF is making a big transition to being completely
+                self-staffed next semester, and as part of that process, we are
+                looking to hire students to be OCF Operations staff for the
+                2017-2018 academic year! This includes two paid positions,
+                Operations Assistant and Operations Manager, neither of which
+                require any technical experience. These are very important
+                roles, and without dedicated and passionate students to fill
+                them, the OCF will not be able to stay open next semester.
+            </p>
+
+            <h3>Operations Assistants</h3>
+            <p>
+                Operations Assistants will have the following responsibilities:
+
+                <ul>
+                    <li>Staffing the front desk</li>
+                    <ul>
+                        <li>Maintaining lab security</li>
+                        <li>Providing help to OCF members using the lab</li>
+                        <li>Carrying out regular lab maintenance</li>
+                    </ul>
+                    <li>Working on projects that benefit the OCF</li>
+                    <ul>
+                        <li>Marketing and outreach</li>
+                        <li>Collecting feedback on OCF services</li>
+                        <li>Organizing events taking place in the lab</li>
+                        <li>Researching and applying for additional sources of
+                            funding for the OCF</li>
+                    </ul>
+                    <li>Attending regular meetings with the Operations Manager
+                        and the other Operations Assistants</li>
+                </ul>
+
+                This job position will be paid $13.75 per hour, but will also be
+                less work and more flexible than the Operations Manager
+                position. See the
+                <a href="https://docs.google.com/document/d/1oS3ma415LbtuyeEuuoucWKYLcWOJaWmzhv2nIs5f718/edit">full job description</a>
+                for more details.
+            </p>
+
+            <h3>Operations Manager</h3>
+            <p>
+                The Operations Manager will have the same responsibilities as
+                the Operations Assistants (see above), except they will spend
+                less time staffing the front desk of the OCF, and instead will
+                spend the remaining time performing more managerial duties,
+                such as leading meetings with the Operations Assistants,
+                delegating projects, and scheduling shifts for the OCF front
+                desk. This job will involve more work than the Operations
+                Assistant role, but it is also paid more, at $15.75 per hour.
+                See the
+                <a href="https://docs.google.com/document/d/1oS3ma415LbtuyeEuuoucWKYLcWOJaWmzhv2nIs5f718/edit#bookmark=id.im3qxqp4zku2">full job description</a>
+                for more details.
+            </p>
+
+            <h3>Application</h3>
+            <p>
+                <a href="https://docs.google.com/a/berkeley.edu/forms/d/e/1FAIpQLSf4sSEdCg6gDbgYJPPvxtXKIcuveygjCBFg_pWuwWoRIFXpXQ/viewform">Apply online</a>
+                for either position. Applications close on Tuesday, April 7th
+                at 11:59 PM, so make sure to apply by then if you would like to
+                be considered.
+            </p>
+            <p>
+                We will let you know if you have been selected for a 30 minute
+                interview by April 9th, and the interviews will be held
+                starting April 11th and going through April 14th.
+            </p>
+            <p>
+              If you have any questions about either position, don't hesitate to
+              <a href="{% url 'doc' 'contact' %}">contact us</a>!
+            </p>
+        </div>
+
+        <div class="col-sm-4 ocf-sidebar">
+          <hr class="visible-sm" />
+            <h3>About the OCF</h3>
+            <p>
+                The OCF provides free computing services for any students,
+                faculty, or staff that lacks access to the resources they need.
+                Since its founding in 1989, the services offered by the OCF
+                have grown massively, especially in the past couple years as
+                the OCF moved to a much nicer new lab location in 171 MLK
+                Student Union.
+            </p>
+            <p>
+                Some of the variety of services we provide to the campus
+                community include:
+            </p>
+            <ul>
+                <li>
+                    <a href="{% url 'doc' 'services/lab' %}">
+                        A spiffy computer lab in 171 MLK</a>, visited by around
+                    500 students per day, and over 10,000 per year
+                </li>
+                <li>
+                    <a href="{% url 'doc' 'services/web' %}">Web, application,
+                        and email hosting</a> for over 80% of student groups and
+                    thousands of individual students
+                </li>
+                <li>
+                    <a href="{% url 'doc' 'services/lab/printing' %}">Free
+                        printing</a>, used by over 5,000 students per semester
+                </li>
+            </ul>
+            <hr />
+            <p class="text-center">
+                <img src="{% static 'img/penguin.svg' %}" />
+            </p>
+        </div>
+    </div>
+{% endblock %}

--- a/ocfweb/announcements/templates/announcements/2017-03-20-hiring.html
+++ b/ocfweb/announcements/templates/announcements/2017-03-20-hiring.html
@@ -8,14 +8,15 @@
             <p><em>March 20, 2017</em></p>
             <hr />
             <p>
-                The OCF is making a big transition to being completely
-                self-staffed next semester, and as part of that process, we are
-                looking to hire students to be OCF Operations staff for the
-                2017-2018 academic year! This includes two paid positions,
-                Operations Assistant and Operations Manager, neither of which
-                require any technical experience. These are very important
-                roles, and without dedicated and passionate students to fill
-                them, the OCF will not be able to stay open next semester.
+                The OCF is making a big transition to having a completely
+                self-staffed front desk next semester, and as part of that
+                process, we are looking to hire students to be OCF Operations
+                staff for the 2017-2018 academic year! This includes two paid
+                positions, Operations Assistant and Operations Manager, neither
+                of which require any technical experience. These are very
+                important roles, and without dedicated and passionate students
+                to fill them, the OCF will not be able to stay open next
+                semester.
             </p>
 
             <h3>Operations Assistants</h3>
@@ -41,9 +42,9 @@
                         and the other Operations Assistants</li>
                 </ul>
 
-                This job position will be paid $13.75 per hour, but will also be
-                less work and more flexible than the Operations Manager
-                position. See the
+                This job position will be paid $13.75 per hour, but will also
+                have less responsibilities and be more flexible than the
+                Operations Manager position. See the
                 <a href="https://docs.google.com/document/d/1oS3ma415LbtuyeEuuoucWKYLcWOJaWmzhv2nIs5f718/edit">full job description</a>
                 for more details.
             </p>
@@ -56,8 +57,9 @@
                 spend the remaining time performing more managerial duties,
                 such as leading meetings with the Operations Assistants,
                 delegating projects, and scheduling shifts for the OCF front
-                desk. This job will involve more work than the Operations
-                Assistant role, but it is also paid more, at $15.75 per hour.
+                desk. This job will involve more responsibilities and use of
+                communication skills than the Operations Assistant role, but it
+                is also paid more, at $15.75 per hour.
                 See the
                 <a href="https://docs.google.com/document/d/1oS3ma415LbtuyeEuuoucWKYLcWOJaWmzhv2nIs5f718/edit#bookmark=id.im3qxqp4zku2">full job description</a>
                 for more details.


### PR DESCRIPTION
Here's a draft of the hiring announcement! (Accessible from inside the OCF subnet at https://fireball.ocf.berkeley.edu/announcements/2017-03-20/hiring if you want a live page)

Unfortunately I have a CS 170 midterm tonight, so I can't be at BoD and discuss this, but leave suggestions for what to change on this pull request (and push changes) and hopefully we can merge it tonight so that we can publicize it a lot more this week.

Obligatory screenshot:
![screenshot](https://cloud.githubusercontent.com/assets/1523594/24122292/7b771c50-0d78-11e7-988a-ff2212beba5f.png)

One thing I'm not sure about is the sidebar to the right, it seems like it's a little unnecessary, but it also felt really empty without having it there. My intention with it was to give some background on the OCF and our impact (and a picture, since otherwise it's a wall of text), but something else might work better there. I also like stealing from the [April fools announcement](https://www.ocf.berkeley.edu/announcements/2016-04-01/renaming-ocf), so there's that...