### PR TITLE
Dutifully destroy documents delivered by alumni

### DIFF
--- a/ocfweb/docs/docs/services/account.md
+++ b/ocfweb/docs/docs/services/account.md
@@ -101,6 +101,9 @@ For security purposes, please include the following with your request:
 If you no longer have your Cal ID, you may substitute it with another
 government-issued ID.
 
+Out of respect for your privacy, any copies of documents you send us will be
+destroyed once we have verified your identity.
+
 ### MySQL
 
 Access to your [[MySQL database|doc services/mysql]], if you have one, is


### PR DESCRIPTION
This isn't really to reassure alumni (most don't express concern for their privacy when they email in docs) but to make sure staff delete private data when it's no longer needed.