### PR TITLE
link to vhost instructions

### DIFF
--- a/ocfweb/account/templates/account/vhost_mail/index.html
+++ b/ocfweb/account/templates/account/vhost_mail/index.html
@@ -13,7 +13,9 @@
             Mail virtual hosting lets you receive mail at a domain like
             <tt>@mygroup.berkeley.edu</tt>. You can create as many
             addresses as you'd like&ndash;for your officers, members,
-            committees, and more.
+            committees, and more. Learn how to send and receive e-mails
+            through Gmail
+            <a href="{% url 'doc' 'services/vhost/mail/gmail' %}">here</a>.
         </p>
 
         {% if vhosts %}


### PR DESCRIPTION
When I was setting up mail-hosting for some of my student groups, I would have to sift through the documentation or google it.  This way once vhosting is setup for a group the link is right there to instructions.