### PR TITLE
change default meeting to staff meeting

### DIFF
--- a/ocfweb/about/templates/about/staff.html
+++ b/ocfweb/about/templates/about/staff.html
@@ -36,10 +36,10 @@
                 </div>
                 <div class="col-sm-6">
                     <div class="ocf-button-holder">
-                        <h2>OCF Board of Directors Meetings</h2>
-                        <p>OCF Staff meet to discuss technology and to make decisions.</p>
+                        <h2>OCF Staff Meetings</h2>
+                        <p>OCF Staff meet to discuss technology, learn from each other, and work on OCF projects.</p>
                         <p>Drop-in visitors are always welcome, especially those interested in joining the staff team!</p>
-                        <p><strong>When:</strong> Every Monday at 7:10pm</p>
+                        <p><strong>When:</strong> Every Monday at 8:10pm</p>
                         <p><strong>Where:</strong> <a href="{% url 'doc' 'services/lab' %}">OCF Computer lab (171 MLK)</a></p>
                     </div>
                 </div>
@@ -128,7 +128,7 @@
         <div class="container">
             <div class="row">
                 <div class="col-md-12">
-                    <h2>We meet every Monday at 7:10pm <a href="{% url 'doc' 'services/lab' %}">in the lab</a>.</h2>
+                    <h2>We meet every Monday at 8:10pm <a href="{% url 'doc' 'services/lab' %}">in the lab</a>.</h2>
                     <h3>We hope to see you there!</h3>
                 </div>
             </div>


### PR DESCRIPTION
about 9 people came last monday at 7:00pm asking when BoD was. these are new staffers we'd ideally like to direct to our new staff meetings, so we should change this wording asap