### PR TITLE
fix trailing whitespace

### DIFF
--- a/ocfweb/docs/docs/services/web/django.md
+++ b/ocfweb/docs/docs/services/web/django.md
@@ -1,6 +1,6 @@
 [[!meta title="Django"]]
 
 **Note: If you are using a group account, you may wish to consider
-[[apphosting|doc services/webapps]] instead. The OCF is currently 
-working on updating this documentation to better help users help 
+[[apphosting|doc services/webapps]] instead. The OCF is currently
+working on updating this documentation to better help users help
 set this up.**


### PR DESCRIPTION
smh