### PR TITLE
remove old references to pmc

### DIFF
--- a/ocfweb/docs/docs/contact.md
+++ b/ocfweb/docs/docs/contact.md
@@ -22,7 +22,7 @@ When contacting OCF staff, please reference
 
 The OCF lab is located on the ground level of MLK Student Union (entrance on
 Lower Sproul), Room 171. You will need to show your student ID to the
-publications staff on desk when you enter the lab.
+front desk staff when you enter the lab.
 
 OCF staff members are usually **not present** during lab open hours. To talk
 with an OCF volunteer staffer, check the [[posted staff hours|staff-hours]].

--- a/ocfweb/docs/docs/services/lab/printing.md
+++ b/ocfweb/docs/docs/services/lab/printing.md
@@ -27,7 +27,7 @@ Check your print balance regularly!
 ## Printing refunds
 
 Pages are **not** normally refunded, except in cases of technical issues. In
-this case, you should talk with the Publications Center staff at the front desk
+this case, you should talk with the OCF Operations Staff at the front desk
 for a refund.
 
 ## Technical details

--- a/ocfweb/docs/templates/docs/lab.html
+++ b/ocfweb/docs/templates/docs/lab.html
@@ -45,8 +45,8 @@
 
                 <h2 id="hours">Hours</h2>
                 <p>
-                    Please note that our hours are all Berkeley Time, as the Publications
-                    and Media Center staff are student employees and may have classes before
+                    Please note that our hours are all Berkeley Time, as the front desk
+                    staff are student employees and may have classes before
                     opening times. Hours for the next week are:
                 </p>
                 <div class="row">
@@ -109,8 +109,7 @@
             <h3 id="help">Need help from an OCF staffer?</h3>
             <p>OCF staff are student volunteers who are <strong>usually not present in the lab</strong>.</p>
             <p>
-                The front desk is staffed by Publications Center
-                employees. While they can help with basic troubleshooting, for
+                The front desk staff can help with basic troubleshooting, but for
                 technical or organization-related questions, it would be better to
                 either chat with an OCF volunteer staffer during
                 <a href="{% url 'staff-hours' %}">staff hours</a> or contact us

--- a/ocfweb/main/templates/main/staff-hours.html
+++ b/ocfweb/main/templates/main/staff-hours.html
@@ -36,7 +36,7 @@
         <h4>Open Computing Facility Lab</h4>
         <p>{% google_map '100%' '250px' %}</p>
         <p><strong>The OCF lab is located on the ground level of MLK Student Union (entrance on Lower Sproul), Room 171.</strong></p>
-        <p>You will need to show your student ID when you pass the Publications Center staff on desk at the entrance.</p>
+        <p>You will need to show your student ID when you pass the front desk at the entrance.</p>
         <p>All staff hours are held in the lab&mdash;feel free to drop by!</p>
 
         <h4>Need help now?</h4>


### PR DESCRIPTION
mostly just used "front desk staff" when possible b/c people won't know what OCF Operations Staff are, and am worried that people will confuse that more with OCF (volunteer) staff.