### PR TITLE
django 1.11: third time's the charm

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,7 @@ mock==2.0.0
 nodeenv==1.2.0
 pbr==3.1.1
 pickleshare==0.7.4
-pre-commit==0.17.0
+pre-commit==0.18.0
 prompt-toolkit==1.0.15
 py==1.4.34
 pytest==3.2.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,13 +12,13 @@ mock==2.0.0
 nodeenv==1.2.0
 pbr==3.1.1
 pickleshare==0.7.4
-pre-commit==0.16.3
+pre-commit==0.17.0
 prompt-toolkit==1.0.15
 py==1.4.34
 pytest==3.2.1
 pytest-django==3.1.2
 requirements-tools==1.1.2
-setuptools==36.2.7
+setuptools==36.3.0
 simplegeneric==0.8.1
 traitlets==4.3.2
 virtualenv==15.1.0

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -4,7 +4,7 @@ django-bootstrap-form
 django-ipware
 django-mathfilters
 django-redis
-django>=1.10,<1.10.999
+django>=1.11,<1.11.999
 gunicorn
 libsass
 matplotlib

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -1,10 +1,10 @@
 cached-property
 celery[redis]
+django
 django-bootstrap-form
 django-ipware
 django-mathfilters
 django-redis
-django>=1.11,<1.11.999
 gunicorn
 libsass
 matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ chardet==3.0.4
 cracklib==2.9.3
 cryptography==2.0.3
 cycler==0.10.0
-Django==1.10.7
+Django==1.11.4
 django-bootstrap-form==3.3
 django-ipware==1.1.6
 django-mathfilters==0.4.0
@@ -31,9 +31,9 @@ paramiko==2.2.1
 pexpect==4.2.1
 ply==3.10
 ptyprocess==0.5.2
-pyasn1==0.3.2
+pyasn1==0.3.3
 pycparser==2.18
-pycryptodome==3.4.6
+pycryptodome==3.4.7
 Pygments==2.2.0
 PyMySQL==0.7.11
 PyNaCl==1.1.2


### PR DESCRIPTION
hopefully, at least. 

django-bootstrap-form 3.3 has been released, as noted earlier, with fixes for Django 1.11.