### PR TITLE
fix hour display bug

### DIFF
--- a/ocfweb/api/hours.py
+++ b/ocfweb/api/hours.py
@@ -85,7 +85,7 @@ def _combine_shifts(shifts):
                 shift.staffer == next_shift.staffer:
             shift = _merge_shifts(shift, next_shift)
         else:
-            combined_shifts.append(next_shift)
+            combined_shifts.append(shift)
             shift = next_shift
 
     # tail case where staffer condition doesn't trip on list end


### PR DESCRIPTION
We were dropping a lot of shifts before resulting in perforated hours on the site.
After much pdb-ing, issue was found to be wrong variable name used.