### PR TITLE
Add software mirrors to services

### DIFF
--- a/ocfweb/docs/docs/services/mirrors.md
+++ b/ocfweb/docs/docs/services/mirrors.md
@@ -1,0 +1,30 @@
+[[!meta title="Software Mirrors"]]
+
+The OCF provides public mirrors of free and open-source software projects for
+anyone to use. These mirrors are available using any of the following protocols:
+
+  - http: [http://mirrors.ocf.berkeley.edu/](http://mirrors.ocf.berkeley.edu/)
+  - https: [https://mirrors.ocf.berkeley.edu/](https://mirrors.ocf.berkeley.edu/)
+  - ftp: [ftp://mirrors.ocf.berkeley.edu/](ftp://mirrors.ocf.berkeley.edu/)
+  - rsync: [rsync://mirrors.ocf.berkeley.edu/](rsync://mirrors.ocf.berkeley.edu/)
+
+To request for another project to be mirrored or to report a problem, please
+[[contact us|doc contact]].
+
+## Currently mirrored projects
+
+  - [Apache Projects](http://www.apache.org/)
+  - [Arch Linux](https://www.archlinux.org/)
+  - [CentOS](https://www.centos.org/)
+  - [Debian](https://www.debian.org/)
+  - [Finnix](https://www.finnix.org/)
+  - [GNU](https://www.gnu.org/)
+  - [Kali Linux](https://www.kali.org/)
+  - [Manjaro](https://manjaro.org/)
+  - [Parrot Project](https://www.parrotsec.org/)
+  - [Puppet](https://puppet.com/)
+  - [Raspbian](https://www.raspbian.org/)
+  - [Tails](https://tails.boum.org/)
+  - [Tanglu](http://www.tanglu.org/)
+  - [Trisquel](https://trisquel.info/)
+  - [Ubuntu](https://www.ubuntu.com/)

--- a/ocfweb/docs/docs/services/mirrors.md
+++ b/ocfweb/docs/docs/services/mirrors.md
@@ -8,6 +8,9 @@ anyone to use. These mirrors are available using any of the following protocols:
   - ftp: [ftp://mirrors.ocf.berkeley.edu/](ftp://mirrors.ocf.berkeley.edu/)
   - rsync: [rsync://mirrors.ocf.berkeley.edu/](rsync://mirrors.ocf.berkeley.edu/)
 
+We are also available at `mirrors.berkeley.edu`, as an alias for
+`mirrors.ocf.berkeley.edu`.
+
 To request for another project to be mirrored or to report a problem with our
 mirroring service, please [[contact us|doc contact]].
 

--- a/ocfweb/docs/docs/services/mirrors.md
+++ b/ocfweb/docs/docs/services/mirrors.md
@@ -8,12 +8,12 @@ anyone to use. These mirrors are available using any of the following protocols:
   - ftp: [ftp://mirrors.ocf.berkeley.edu/](ftp://mirrors.ocf.berkeley.edu/)
   - rsync: [rsync://mirrors.ocf.berkeley.edu/](rsync://mirrors.ocf.berkeley.edu/)
 
-To request for another project to be mirrored or to report a problem, please
-[[contact us|doc contact]].
+To request for another project to be mirrored or to report a problem with our
+mirroring service, please [[contact us|doc contact]].
 
 ## Currently mirrored projects
 
-  - [Apache Projects](http://www.apache.org/)
+  - [Apache Projects](https://www.apache.org/)
   - [Arch Linux](https://www.archlinux.org/)
   - [CentOS](https://www.centos.org/)
   - [Debian](https://www.debian.org/)
@@ -23,6 +23,7 @@ To request for another project to be mirrored or to report a problem, please
   - [Manjaro](https://manjaro.org/)
   - [Parrot Project](https://www.parrotsec.org/)
   - [Puppet](https://puppet.com/)
+  - [Qt](https://www.qt.io/)
   - [Raspbian](https://www.raspbian.org/)
   - [Tails](https://tails.boum.org/)
   - [Tanglu](http://www.tanglu.org/)

--- a/ocfweb/templates/base.html
+++ b/ocfweb/templates/base.html
@@ -54,6 +54,7 @@
                                 <li><a href="{% url 'doc' 'services/shell' %}">SSH/SFTP (Shell)</a></li>
                                 <li><a href="{% url 'doc' 'services/mail' %}">Email Hosting</a></li>
                                 <li><a href="{% url 'doc' 'services/mysql' %}">MySQL Database</a></li>
+                                <li><a href="{% url 'doc' 'services/mirrors' %}">Software Mirrors</a></li>
                             </ul>
                         </li>
 


### PR DESCRIPTION
We don't really publicize our software mirrors anywhere, so I thought it would be good to put a list of projects we mirror somewhere on the website.