### PR TITLE
Fix missing files on Jenkinsfile unstash

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ try {
             }
         }
 
-        stash 'src'
+        stash name: 'src', useDefaultExcludes: false
     }
 
     def version = "${new Date().format("yyyy-MM-dd-'T'HH-mm-ss")}-git${sha}"
@@ -39,6 +39,7 @@ try {
         parallel(
             test: {
                 node('slave') {
+                    step([$class: 'WsCleanup'])
                     unstash 'src'
                     stage('test') {
                         dir('src') {


### PR DESCRIPTION
I found [JENKINS-31086](https://issues.jenkins-ci.org/browse/JENKINS-31086) which seems to be exactly the problem we're having. It links to https://github.com/jenkinsci/pipeline-plugin/pull/266 which provides an option to fix it, so hopefully the build eventually passes!

EDIT: [Here's an example where this occurs](https://jenkins.ocf.berkeley.edu/blue/organizations/jenkins/ocfweb/detail/PR-318/7/pipeline). Thanks to @jvperrin for [finding out what was causing the failure](https://gist.github.com/jvperrin/5ca1f0976d1617f728a6631d7511d4d0).