### PR TITLE
Specify the exception type gethostbyaddr() throws.

### DIFF
--- a/ocfweb/account/vhost.py
+++ b/ocfweb/account/vhost.py
@@ -76,7 +76,7 @@ def request_vhost(request):
 
                 try:
                     ip_reverse = socket.gethostbyaddr(ip_addr)[0]
-                except:
+                except socket.herror:
                     ip_reverse = 'unknown'
 
                 subject = 'Virtual Hosting Request: {} ({})'.format(

--- a/ocfweb/account/vhost_mail.py
+++ b/ocfweb/account/vhost_mail.py
@@ -389,7 +389,7 @@ def _txn(**kwargs):
     ) as c:
         try:
             yield c
-        except:
+        except Exception:
             c.connection.rollback()
             raise
         else:


### PR DESCRIPTION
Flake8 was complaining during testing, so I added the specific [exception](https://docs.python.org/3/library/socket.html#socket.herror).

It also complained about a bare except in vhost_mail.py, but I looked in PyMySQL's source code and the connection object throws several exception types, so a bare except is probably OK there.