### PR TITLE
tv/hours: fix background positioning

### DIFF
--- a/ocfweb/static/scss/pages/_tv.scss
+++ b/ocfweb/static/scss/pages/_tv.scss
@@ -2,17 +2,22 @@ $base-font-size: 6vw;
 $tv-hours-large: 12;
 $tv-hours-small: 5;
 
+.page-tv-hours {
+    body {
+        background-image: url('../img/tv/background.png');
+        background-attachment: fixed;
+        background-repeat: no-repeat;
+        background-position: center center;
+        background-size: cover;
+    }
+}
+
 .page-tv {
 
-    background-image: url('../img/tv/background.png');
-    background-attachment: fixed;
-    background-repeat: no-repeat;
-    background-size: cover;
-    height: 100vh;
-
-    .page-tv-hours {
+    .tv-hours {
 
         @extend .text-center;
+        padding-top: 10vh;
 
         font-size: $base-font-size;
 

--- a/ocfweb/tv/templates/tv/base.html
+++ b/ocfweb/tv/templates/tv/base.html
@@ -1,6 +1,6 @@
 <!doctype html>
 
-<html>
+<html class="{{base_css_classes}}">
 
   {% include 'partials/head.html' %}
   <meta http-equiv='refresh' content='600' />

--- a/ocfweb/tv/templates/tv/hours.html
+++ b/ocfweb/tv/templates/tv/hours.html
@@ -2,7 +2,7 @@
 {% load tv_formatting %}
 
 {% block tv-body %}
-<div class="page-tv-hours">
+<div class="tv-hours">
   <p> Hours for {{ hours.date | date:'l, M j' }} </p>
   <div class="hours-container {{ hours.hours | tv_lab_hours_css }}">
     {% for hour in hours.hours %}


### PR DESCRIPTION
the top of the background was getting cut off on ocf-tv @abizer 

check:
http://supernova.ocf.berkeley.edu:8513/tv/hours/

![image](https://user-images.githubusercontent.com/15065181/32974965-8af6625a-cbb7-11e7-80ee-bdcce6a43a5a.png)