### PR TITLE
Auto-minify JS and CSS.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update \
         redis-tools \
         runit \
         virtualenv \
+        yui-compressor \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.static.in
+++ b/Dockerfile.static.in
@@ -1,6 +1,8 @@
 FROM {tag}
 
 RUN /opt/ocfweb/venv/bin/sassc /opt/ocfweb/ocfweb/static/scss/site.scss /opt/ocfweb/ocfweb/static/scss/site.scss.css
+RUN yui-compressor -o /opt/ocfweb/ocfweb/static/scss/site.scss.css /opt/ocfweb/ocfweb/static/scss/site.scss.css
+RUN yui-compressor -o '.js$:.js' /opt/ocfweb/ocfweb/static/js/*.js --nomunge
 RUN mkdir /opt/ocfweb/static
 ENV OCFWEB_STATIC_ROOT /opt/ocfweb/static
 RUN /opt/ocfweb/venv/bin/python /opt/ocfweb/manage.py collectstatic --noinput

--- a/Dockerfile.static.in
+++ b/Dockerfile.static.in
@@ -1,8 +1,7 @@
 FROM {tag}
 
 RUN /opt/ocfweb/venv/bin/sassc /opt/ocfweb/ocfweb/static/scss/site.scss /opt/ocfweb/ocfweb/static/scss/site.scss.css
-RUN yui-compressor -o /opt/ocfweb/ocfweb/static/scss/site.scss.css /opt/ocfweb/ocfweb/static/scss/site.scss.css
-RUN yui-compressor -o '.js$:.js' /opt/ocfweb/ocfweb/static/js/*.js --nomunge
+RUN find /opt/ocfweb/ocfweb/ \( -name '*.js' -o -name '*.css' \) -exec yui-compressor -o {} {} \;
 RUN mkdir /opt/ocfweb/static
 ENV OCFWEB_STATIC_ROOT /opt/ocfweb/static
 RUN /opt/ocfweb/venv/bin/python /opt/ocfweb/manage.py collectstatic --noinput


### PR DESCRIPTION
Should resolve #218 

Unfortunately, yui-compressor's output wildcard syntax fails when there's only one input file through the wildcard, so I had to hardcode minifying the CSS file.