### PR TITLE
Proposal: add temporary net neutrality modal on ocfweb pages

### DIFF
--- a/ocfweb/templates/base.html
+++ b/ocfweb/templates/base.html
@@ -230,5 +230,14 @@
 
         {% include "partials/google-analytics.html" %}
         {% block inline_js %}{% endblock %}
+
+        <!-- TODO: disable after December 14 vote -->
+        <script>
+            var _bftn_options = {
+                theme: {headline: 'Stand with the OCF on internet freedom.'},
+                disableGoogleAnalytics: true
+            };
+        </script>
+        <script src="https://widget.battleforthenet.com/widget.js" async></script>
     </body>
 </html>


### PR DESCRIPTION
This seemed to have general support when I mentioned it on IRC yesterday (technically I proposed changing our desktop home pages, but this also works).

This shows the modal in the screenshot below on all ocfweb pages, only on the first page view. I added a custom title (wanted to include "OCF" in the text, to maybe make it seem less spammy) and turned off GA tracking on the modal. Also the "countdown" theme seemed to be the least confusing, so I went with that one.

Thoughts?

![](https://i.fluffy.cc/t43DJlTrxTML7jXvcnkQnZjhMKsLxv6t.png)