### PR TITLE
hiding regular hours by default

### DIFF
--- a/ocfweb/docs/templates/docs/lab.html
+++ b/ocfweb/docs/templates/docs/lab.html
@@ -71,7 +71,9 @@
                 </div>
 
 
-                <h3>Regular Weekly Hours</h3>
+		<h3>Regular Weekly Hours</h3>
+		<button class = "btn btn-primary" id = "weekly_hours_btn" onclick="toggle_weekly_hours()" style="opacity:0.3;">Show</button>
+		<div id = "weekly_hours" style="display:none;">
                 <p>The regular OCF hours are:</p>
                 <div class="row">
                     <div class="col-sm-8">
@@ -86,6 +88,7 @@
                         </table>
                     </div>
                 </div>
+		</div>
 
                 {% if holidays %}
                     <h3 id="holidays">{{semester}} Holidays</h3>
@@ -131,4 +134,19 @@
             </video>
         </div>
     </div>
+
+    <script>
+	function toggle_weekly_hours() {
+		var change = document.getElementById("weekly_hours_btn");
+		if (change.innerHTML == "Show")
+		{
+			change.innerHTML = "Hide";
+			$("#weekly_hours").show();
+		}
+		else {
+			change.innerHTML = "Show";
+			$("#weekly_hours").hide();
+		}
+	}
+    </script>
 {% endblock %}


### PR DESCRIPTION
I changed ocf.berkeley.edu/docs/services/lab/ and made the regular weekly hours hidden by default. The reasoning for this change is because Sahil said that people would ignore the actual hours above the regular weekly hours and get confused about lab opening times...

Screenshots of the page on load and after button click are attached.
![hours_hidden](https://user-images.githubusercontent.com/8411302/33303067-700ac6ec-d3b5-11e7-83ed-1c615d510144.png)
![hours_shown](https://user-images.githubusercontent.com/8411302/33303068-701d33f4-d3b5-11e7-9370-dcf09cbb2181.png)