### PR TITLE
Add clarification to approve docs for non-student groups

### DIFF
--- a/ocfweb/docs/docs/staff/scripts/approve.md
+++ b/ocfweb/docs/docs/staff/scripts/approve.md
@@ -69,7 +69,7 @@ deprecated.
 Optionally, if you pass the OID as the only argument, the `group_name`,
 `callink_oid`, and `email` fields will get filled in automatically using the
 group's public information on CalLink. If the group is not a student group,
-(i.e. a research group), use 0 as the OID.
+(e.g. a research group), use 0 as the OID.
 
 
 ### Post approval

--- a/ocfweb/docs/docs/staff/scripts/approve.md
+++ b/ocfweb/docs/docs/staff/scripts/approve.md
@@ -68,7 +68,8 @@ deprecated.
 
 Optionally, if you pass the OID as the only argument, the `group_name`,
 `callink_oid`, and `email` fields will get filled in automatically using the
-group's public information on CalLink.
+group's public information on CalLink. If the group is not a student group,
+(i.e. a research group), use 0 as the OID.
 
 
 ### Post approval


### PR DESCRIPTION
This just documents that OID should be 0 when approving non student group accounts.