### PR TITLE
Fixed previous error404 commit

### DIFF
--- a/ocfweb/context_processors.py
+++ b/ocfweb/context_processors.py
@@ -14,7 +14,7 @@ from ocfweb.environment import ocfweb_version
 
 
 def get_base_css_classes(request):
-    if request.resolver_match.url_name:
+    if request.resolver_match and request.resolver_match.url_name:
         page_class = 'page-' + request.resolver_match.url_name
         yield page_class
 

--- a/ocfweb/errors/errors.py
+++ b/ocfweb/errors/errors.py
@@ -1,6 +1,0 @@
-from django.shortcuts import render
-
-
-def http404(request):
-    """ Function for rendering the error 404 page. """
-    return render(request, 'errors/404.html')

--- a/ocfweb/settings.py
+++ b/ocfweb/settings.py
@@ -33,7 +33,6 @@ INSTALLED_APPS = (
     'ocfweb.docs',
     'ocfweb.login',
     'ocfweb.main',
-    'ocfweb.errors',
     'ocfweb.middleware',
     'ocfweb.stats',
     'ocfweb.test',

--- a/ocfweb/templates/404.html
+++ b/ocfweb/templates/404.html
@@ -14,6 +14,6 @@
         height: 1000px;
     }
 </style>
-     <img src="{% static 'img/404penguin.png' %}" alt="Mountain View" style='height: 100%; width: 100%'/>
+     <img src="{% static 'img/404penguin.png' %}" alt="404 Penguin" style='height: 100%; width: 100%'/>
 </div>
 {% endblock %}

--- a/ocfweb/urls.py
+++ b/ocfweb/urls.py
@@ -10,7 +10,6 @@ from ocfweb.account.urls import urlpatterns as account
 from ocfweb.announcements.urls import urlpatterns as announcements
 from ocfweb.api.urls import urlpatterns as api
 from ocfweb.docs.urls import urlpatterns as docs
-from ocfweb.errors import errors
 from ocfweb.lab_reservations.urls import urlpatterns as lab_reservations
 from ocfweb.login.urls import urlpatterns as login
 from ocfweb.main.favicon import favicon
@@ -23,11 +22,7 @@ from ocfweb.test.periodic import test_list_periodic_functions
 from ocfweb.test.session import test_session
 from ocfweb.tv.urls import urlpatterns as tv
 
-handler404 = errors.http404
-
 urlpatterns = [
-    url(r'^404/', handler404),
-
     # test pages
     url(r'^test/status$', lambda _: HttpResponse('ok'), name='status'),
     url(r'^test/session$', test_session, name='test_session'),


### PR DESCRIPTION
There were some complications with loading static pages when DEBUG was set to False to test the 404 page on supernova. I was able to get around this and load the static files by adding `--insecure` when running `manage.py runserver`.