### PR TITLE
Use pytest-cov for coverage reporting, bump requirements

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 branch = True
+source = ocfweb,tests
 
 [report]
 show_missing = True

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,8 +44,11 @@ pipeline {
       }
       parallel {
         stage('test') {
+          environment {
+            COVERALLS_REPO_TOKEN = credentials('coveralls_token')
+          }
           steps {
-            sh 'make test'
+            sh 'make coveralls'
           }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@ pipeline {
       parallel {
         stage('test') {
           environment {
-            COVERALLS_REPO_TOKEN = credentials('coveralls_token')
+            COVERALLS_REPO_TOKEN = credentials('coveralls_ocfweb_token')
           }
           steps {
             sh 'make coveralls'

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,7 @@ DOCKER_TAG_STATIC = $(DOCKER_REPO)ocfweb-static:$(DOCKER_REVISION)
 .PHONY: test
 test: export OCFWEB_TESTING ?= 1
 test: venv
-	$(BIN)/coverage run -m py.test -v tests/
-	$(BIN)/coverage report
+	$(BIN)/py.test -v tests/
 	$(BIN)/pre-commit run --all-files
 
 .PHONY: Dockerfile.%

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,7 +5,7 @@ DJANGO_SETTINGS_MODULE=ocfweb.settings
 # you find that this is using too much CPU, change 'auto' to the number of CPUs
 # you want to parallize across. See https://docs.pytest.org/en/3.0.0/xdist.html
 # for more details on available options
-addopts=--durations=10 -n auto
+addopts=--cov --cov-report=term-missing --durations=10 -n auto
 
 # Unfortunately this is needed to make pytest-xdist order tests correctly
 # between workers to not fail to run any tests due to mismatched test sets

--- a/requirements-dev-minimal.txt
+++ b/requirements-dev-minimal.txt
@@ -2,6 +2,8 @@ coveralls
 pre-commit
 pytest
 pytest-cov
+# pytest-django 3.4.0 and 3.4.1 cause test errors with hosting icons that
+# aren't actual errors
 pytest-django<=3.4.0
 pytest-env
 pytest-xdist

--- a/requirements-dev-minimal.txt
+++ b/requirements-dev-minimal.txt
@@ -1,8 +1,8 @@
-coverage
 coveralls
 pre-commit
 pytest
-pytest-django
+pytest-cov
+pytest-django<=3.4.0
 pytest-env
 pytest-xdist
 requirements-tools

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,8 @@ pathlib2==2.3.2
 pluggy==0.7.1
 pre-commit==1.10.5
 py==1.5.4
-pytest==3.7.1
+pytest==3.7.2
+pytest-cov==2.5.1
 pytest-django==3.3.3
 pytest-env==0.6.2
 pytest-forked==0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,11 +4,11 @@ bcrypt==3.1.4
 billiard==3.5.0.4
 cached-property==1.4.3
 celery==4.2.1
-certifi==2018.4.16
+certifi==2018.8.13
 cffi==1.11.5
 chardet==3.0.4
 cracklib==2.9.3
-cryptography==2.3
+cryptography==2.3.1
 cycler==0.10.0
 Django==2.1
 django-bootstrap-form==3.4
@@ -24,7 +24,7 @@ kombu==4.2.1
 ldap3==2.5.1
 libsass==0.14.5
 MarkupSafe==1.0
-matplotlib==2.2.2
+matplotlib==2.2.3
 mistune==0.8.3
 numpy==1.15.0
 ocflib
@@ -34,8 +34,8 @@ ply==3.11
 ptyprocess==0.6.0
 pyasn1==0.4.4
 pycparser==2.18
-pycryptodome==3.6.4
-pycryptodomex==3.6.4
+pycryptodome==3.6.6
+pycryptodomex==3.6.6
 Pygments==2.2.0
 PyMySQL==0.9.2
 PyNaCl==1.2.1
@@ -47,7 +47,7 @@ pytz==2018.5
 PyYAML==3.13
 redis==2.10.6
 requests==2.19.1
-setuptools==40.0.0
+setuptools==40.1.0
 six==1.11.0
 SQLAlchemy==1.2.10
 urllib3==1.23


### PR DESCRIPTION
Once #388 is merged to change the structure of the `Jenkinsfile`, we should also start running `make coveralls` instead of `make test` so that coverage starts getting reported again (it was last reported in 2016).

This is the ocfweb equivalent of ocf/ocflib#134.