### PR TITLE
Removing destruction from auto-occupied on ocf.io/tv/labmap

### DIFF
--- a/ocfweb/tv/templates/tv/labmap.html
+++ b/ocfweb/tv/templates/tv/labmap.html
@@ -1738,7 +1738,6 @@ function makeAPIRequest() {
         //       should be using instead. That better represents the purpose
         //       of this utility anyways.
         id_in_use.add(mapping['eruption']);
-        id_in_use.add(mapping['destruction']);
 
         for (polygon of document.getElementsByClassName('comp')) {
             if (hasOverlap(polygon.classList, id_in_use)) {


### PR DESCRIPTION
Destruction was fixed today so it should be available on labmap again