### PR TITLE
quick wording fix on staff_hours.html

### DIFF
--- a/ocfweb/main/templates/main/staff-hours.html
+++ b/ocfweb/main/templates/main/staff-hours.html
@@ -7,7 +7,7 @@
     <div class="col-sm-8 ocf-content-block">
         <h2>Have questions? Drop by for help from a friendly volunteer staffer!</h2>
         <p>OCF staff members hold regular drop-in staff hours to provide assistance with account issues or with OCF services. We're always happy to help troubleshoot account or service issues!</p>
-        <p>Keep in mind the OCF volunteers sometimes have last-minute conflicts, so it's a good idea to check this page before coming in for cancellations.</p>
+        <p>Keep in mind the OCF volunteers sometimes have last-minute conflicts, so it's a good idea to check this page for cancellations before coming in to the lab.</p>
         {% for staff_hour in staff_hours %}
             <div class="hour {% if staff_hour.cancelled or staff_hour.day == today and lab_status.force_lab_closed %} cancelled {% endif %}">
                 <div class="title">


### PR DESCRIPTION
Simple wording fix; no humans would ever have been confused by this and be paralyzed but some humans would have had to read the sentence twice, myself included. 

This gets rid of that mild inconvenience.

Previous sentence "...so it's a good idea to check this page before coming in for cancellations." could be read as the person is coming to the lab for cancellations rather than staff hour.

The new sentence "...so it's a good idea to check this page for cancellations before coming in to the lab." should be more clear.