### PR TITLE
Fix some django/matplotlib deprecation warnings

### DIFF
--- a/ocfweb/about/templates/about/lab-open-source.html
+++ b/ocfweb/about/templates/about/lab-open-source.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load staticfiles %}
+{% load static %}
 
 {% block hero %}{% endblock %}
 {% block container %}

--- a/ocfweb/about/templates/about/lab-vote.html
+++ b/ocfweb/about/templates/about/lab-vote.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load staticfiles %}
+{% load static %}
 
 {% block hero %}{% endblock %}
 {% block container %}

--- a/ocfweb/about/templates/about/staff.html
+++ b/ocfweb/about/templates/about/staff.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load staticfiles %}
+{% load static %}
 
 {% block hero %}{% endblock %}
 {% block container %}

--- a/ocfweb/account/templates/account/register/index.html
+++ b/ocfweb/account/templates/account/register/index.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% load bootstrap %}
-{% load staticfiles %}
+{% load static %}
 
 {% block content %}
     <div class="row">

--- a/ocfweb/account/templates/account/vhost_mail/index.html
+++ b/ocfweb/account/templates/account/vhost_mail/index.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load common %}
 {% load humanize %}
-{% load staticfiles %}
+{% load static %}
 {% load vhost_mail %}
 
 {% block content %}

--- a/ocfweb/announcements/announcements.py
+++ b/ocfweb/announcements/announcements.py
@@ -4,8 +4,8 @@ from datetime import datetime
 from datetime import time
 
 from cached_property import cached_property
-from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.shortcuts import render
+from django.templatetags.static import static
 from django.urls import reverse
 from django.utils import timezone
 

--- a/ocfweb/announcements/templates/announcements/2016-02-09-printing.html
+++ b/ocfweb/announcements/templates/announcements/2016-02-09-printing.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load staticfiles %}
+{% load static %}
 
 {% block content %}
     <div class="row">

--- a/ocfweb/announcements/templates/announcements/2016-04-01-renaming.html
+++ b/ocfweb/announcements/templates/announcements/2016-04-01-renaming.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load staticfiles %}
+{% load static %}
 
 {% block content %}
     <div class="row">

--- a/ocfweb/announcements/templates/announcements/2016-05-12-ocf-eff-alliance.html
+++ b/ocfweb/announcements/templates/announcements/2016-05-12-ocf-eff-alliance.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load staticfiles %}
+{% load static %}
 
 {% block content %}
     <div class="row">

--- a/ocfweb/announcements/templates/announcements/2017-03-01-hpc-survey.html
+++ b/ocfweb/announcements/templates/announcements/2017-03-01-hpc-survey.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load staticfiles %}
+{% load static %}
 
 {% block content %}
     <div class="row">

--- a/ocfweb/announcements/templates/announcements/2017-03-20-hiring.html
+++ b/ocfweb/announcements/templates/announcements/2017-03-20-hiring.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load staticfiles %}
+{% load static %}
 
 {% block content %}
     <div class="row">

--- a/ocfweb/announcements/templates/announcements/index.html
+++ b/ocfweb/announcements/templates/announcements/index.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% load humanize %}
-{% load staticfiles %}
+{% load static %}
 
 {% block content %}
     <div class="row">

--- a/ocfweb/docs/templates/docs/partials/host.html
+++ b/ocfweb/docs/templates/docs/partials/host.html
@@ -1,5 +1,5 @@
 {% load common %}
-{% load staticfiles %}
+{% load static %}
 
 <div class="row host host-{{host.type}}">
     <div class="col-sm-3">

--- a/ocfweb/lab_reservations/templates/lab_reservations/index.html
+++ b/ocfweb/lab_reservations/templates/lab_reservations/index.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% load bootstrap %}
-{% load staticfiles %}
+{% load static %}
 
 {% block content %}
     <div class="row">

--- a/ocfweb/stats/job_frequency.py
+++ b/ocfweb/stats/job_frequency.py
@@ -86,7 +86,7 @@ def get_jobs_plot(day):
     ax.set_xticks(ticks=tickLocations)
     ax.yaxis.set_major_locator(MaxNLocator(integer=True))
     ax.yaxis.grid(True)
-    ax.set_ylim(ymin=0)
+    ax.set_ylim(bottom=0)
     ax.set_ylabel('Number of Jobs Printed')
     ax.set_title('Print Job Distribution {:%a %b %d}'.format(day))
 

--- a/ocfweb/stats/semester_job.py
+++ b/ocfweb/stats/semester_job.py
@@ -74,7 +74,7 @@ def freq_plot(
     ax.set_xticks(ticks=tickLocations)
     ax.yaxis.set_major_locator(MaxNLocator(integer=True))
     ax.yaxis.grid(True)
-    ax.set_ylim(ymin=0)
+    ax.set_ylim(bottom=0)
     ax.set_ylabel(ylab)
     ax.set_title(title)
 

--- a/ocfweb/stats/session_count.py
+++ b/ocfweb/stats/session_count.py
@@ -74,7 +74,7 @@ def get_sessions_plot(start_day, end_day):
     skip = max(1, len(x) // 5)  # target 5 labels
     ax.set_xticks(x[::skip])
     ax.set_xticklabels(list(map(date.fromtimestamp, x))[::skip])
-    ax.set_ylim(ymin=0)
+    ax.set_ylim(bottom=0)
     ax.set_title('Unique lab logins {} to {}'.format(
         start_day.isoformat(),
         end_day.isoformat(),

--- a/ocfweb/stats/session_length.py
+++ b/ocfweb/stats/session_length.py
@@ -88,7 +88,7 @@ def get_sessions_plot(start_day, end_day):
     skip = max(1, len(x) // 5)  # target 5 labels
     ax.set_xticks(x[::skip])
     ax.set_xticklabels(list(map(date.fromtimestamp, x))[::skip])
-    ax.set_ylim(ymin=0)
+    ax.set_ylim(bottom=0)
     ax.set_ylabel('Duration (hours)')
     ax.set_title('Mean session duration {} to {}'.format(
         start_day.isoformat(),

--- a/ocfweb/templates/404.html
+++ b/ocfweb/templates/404.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load staticfiles %}
+{% load static %}
 
 {% block content %}
 <div>

--- a/ocfweb/templates/base.html
+++ b/ocfweb/templates/base.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 {% load lab_hours %}
 
 <!doctype html>

--- a/ocfweb/templates/partials/head.html
+++ b/ocfweb/templates/partials/head.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
     <head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/ocfweb/templates/partials/open-source-pics.html
+++ b/ocfweb/templates/partials/open-source-pics.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 <p class="ocf-logos">
     <a href="https://www.linuxfoundation.org/"><img src="{% static 'img/about/logos/linux.png' %}" alt="linux" title="Linux" /></a>
     <a href="https://www.debian.org/"><img src="{% static 'img/about/logos/debian.png' %}" alt="debian" title="Debian" /></a>

--- a/ocfweb/tv/templates/tv/labmap.html
+++ b/ocfweb/tv/templates/tv/labmap.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 
 <!DOCTYPE html>
 <meta charset="UTF-8">


### PR DESCRIPTION
These can be seen in the test output, like in https://jenkins.ocf.berkeley.edu/job/ocfweb/job/master/1390/consoleFull (for example)

Aside from the existing tests, I've manually checked the affected pages (stats, announcements, some pages with template changes) to make sure they load properly on my dev instance.