### PR TITLE
Remove survey iframe scrollbar

### DIFF
--- a/ocfweb/about/templates/about/lab-survey.html
+++ b/ocfweb/about/templates/about/lab-survey.html
@@ -13,7 +13,8 @@
             <iframe src="https://goo.gl/Z6rRnE"
             width="640" height="2220"
             frameborder="0" marginheight="0"
-            marginwidth="0">
+            marginwidth="0"
+            scrolling="no">
             Loading...
         </iframe>
             </p>


### PR DESCRIPTION
scrolling, like the other iframe attributes, is deprecated
but still supported by all major browsers.