### PR TITLE
Add hiring status to banner

### DIFF
--- a/ocfweb/templates/base.html
+++ b/ocfweb/templates/base.html
@@ -117,6 +117,11 @@
                         <strong>Lab Temporarily Closed</strong>
                         <a class="subtle" href="{% url 'home' %}">more &raquo;</a>
                     {% endif %}
+
+            <br>
+
+                    <strong>Lab Currently Hiring</strong>
+                    <a class="subtle" href="{% url 'hiring-2018-announcement' %}">more &raquo;</a>
                 </p>
             </div>
         </div>


### PR DESCRIPTION
Add hiring announcement to the banner to increase visibility
Results: https://i.fluffy.cc/rHw00JKNS8JmPWvh2qJPJCDjzpPkmSp6.png

We may want to reword 'Lab Currently Hiring' to something else, perhaps 'The Lab is Currently Hiring'