### PR TITLE
Change username validation warning to yellow

### DIFF
--- a/ocfweb/account/constants.py
+++ b/ocfweb/account/constants.py
@@ -10,6 +10,7 @@ TESTER_CALNET_UIDS = (
     1034192,  # ckuehl
     869331,   # tzhu
     1031366,  # mattmcal
+    1099131,  # dkessler
     1101587,  # jvperrin
 )
 

--- a/ocfweb/account/register.py
+++ b/ocfweb/account/register.py
@@ -144,6 +144,7 @@ def validate(request):
     except (ValidationError, ValidationWarning) as e:
         return JsonResponse({
             'is_valid': False,
+            'is_warning': isinstance(e, ValidationWarning),
             'msg': str(e),
         })
 

--- a/ocfweb/account/templates/account/register/index.html
+++ b/ocfweb/account/templates/account/register/index.html
@@ -55,7 +55,7 @@
                 <div class="container-fluid">
                     <div class="row">
                         <div class="col-sm-7">
-                            <p>Your account name must consist of between three and 16 lowercase letters (no spaces, numbers, underscores, or other symbols), and it <strong><strong>MUST</strong> be based on your real name or initials.</strong></p>
+                            <p>Your account name must consist of between three and 16 lowercase letters (no spaces, numbers, underscores, or other symbols), and it <strong><strong>must</strong> be based on your real name or initials.</strong></p>
                             {{form.ocf_login_name|bootstrap}}
                             <div class="alert username-feedback" role="alert" id="username-feedback"></div>
                         </div>

--- a/ocfweb/static/js/pages/account/register.js
+++ b/ocfweb/static/js/pages/account/register.js
@@ -7,18 +7,26 @@ function validate_username() {
          data: {'username': $username_field.val(),
                 'real_name': $('#real-name').text()},
          success: function(data) {
+             var msg = data.msg;
+
              if(data.is_valid) {
                 $username_field.parent().removeClass('has-error')
                                .addClass('has-success');
-                $username_feedback.removeClass('alert-danger')
+                $username_feedback.removeClass('alert-danger alert-warning')
                                   .addClass('alert-success');
              } else {
                 $username_field.parent().removeClass('has-success')
                                .addClass('has-error');
                 $username_feedback.removeClass('alert-sucess')
                                   .addClass('alert-danger');
+                if (data.is_warning) {
+                    msg += ' Your account will require manual approval.';
+                    msg += ' Email help@ocf.berkeley.edu if you have questions.';
+                    $username_feedback.removeClass('alert-danger')
+                                      .addClass('alert-warning');
+                }
              }
-             $username_feedback.show().text(data.msg);
+             $username_feedback.show().text(msg);
          }
      });
  }


### PR DESCRIPTION
The current interface doesn't really make it clear that it's OK for one's username to not exactly match our "similarity" filter. I'm open to suggestions about how to word this better, though.

Before:
![screenshot_2018-11-14_16-36-51](https://user-images.githubusercontent.com/749522/48522368-3b3fa800-e82d-11e8-8aad-0944e6057b15.png)

After:
![screenshot_2018-11-14_16-05-57](https://user-images.githubusercontent.com/749522/48522367-3b3fa800-e82d-11e8-820f-40ae79e094c4.png)
