### PR TITLE
Reverse list of officers so recent terms are on top

### DIFF
--- a/ocfweb/docs/views/officers.py
+++ b/ocfweb/docs/views/officers.py
@@ -234,6 +234,6 @@ def officers(doc, request):
         {
             'title': doc.title,
             'current_term': terms[-1],
-            'previous_terms': terms[:-1],
+            'previous_terms': reversed(terms[:-1]),
         },
     )


### PR DESCRIPTION
This makes the officers page flow more nicely.

cue bikeshedding on why we shouldn't do this