### PR TITLE
settings: make ALLOWED_HOSTS accept all

### DIFF
--- a/ocfweb/settings.py
+++ b/ocfweb/settings.py
@@ -11,12 +11,8 @@ from django.template.base import TemplateSyntaxError
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 TESTING = os.environ.get('OCFWEB_TESTING') == '1'
 
-ALLOWED_HOSTS = [
-    'www.ocf.berkeley.edu',
-    'dev.ocf.berkeley.edu',
-    'dev-www.ocf.berkeley.edu',
-    'ocfweb.ocf.berkeley.edu',
-]
+# This is checked by marathon-lb anyways
+ALLOWED_HOSTS = ['*']
 
 INSTALLED_APPS = (
     'bootstrapform',


### PR DESCRIPTION
I realize this is [not recommended by the Django devs](https://docs.djangoproject.com/en/2.1/ref/settings/#allowed-hosts), but I don't think their precautions affect us because marathon-lb is checking the HOST header anyways.

This would make Prometheus metrics monitoring a lot easier-- Prometheus can't scrape directly from www.ocf.berkeley.edu because that would randomly pick from the load balancer-- instead, we want it to bypass the load balancer and scrape each target individually (this part is already configured).

Unfortunately, if our host is, say, "jaws:31954", the request will be rejected by Django because it doesn't match up. We could get around this in many ways-- the easiest would be putting an nginx somewhere that replaces this header-- but I believe this is the simplest way to handle the problem.

I noticed that we planned on doing this in 08bc478a4072048cbeb825e6afad6faa851017b9, but it was reverted the next day in 8c634ed67a1eb0a4eee5388148cd3035cd48f8ba. I couldn't find any extra context on this from IRC logs.