### PR TITLE
Allow markdown hard line breaks without trailing spaces

### DIFF
--- a/ocfweb/component/markdown.py
+++ b/ocfweb/component/markdown.py
@@ -52,7 +52,7 @@ class BackslashLineBreakLexerMixin:
 
     def enable_backslash_line_breaks(self):
         self.rules.backslash_line_break = re.compile(
-            '^(\\\\)\n',
+            '^\\\\\n',
         )
         self.default_rules.insert(0, 'backslash_line_break')
 

--- a/ocfweb/docs/docs/staff/backend/libvirt.md
+++ b/ocfweb/docs/docs/staff/backend/libvirt.md
@@ -144,7 +144,7 @@ Find the lvm vg
 On the hypervisor,
 
     virsh dominfo <vm>
-    virsh domblkinfo <vm>  
+    virsh domblkinfo <vm>
     lvextend /dev/vg/<vm> -L20G
     virsh blockresize <vm> /dev/vda 20G
 

--- a/ocfweb/docs/docs/staff/backend/switch.md
+++ b/ocfweb/docs/docs/staff/backend/switch.md
@@ -35,7 +35,7 @@ the OCF subnet.
 ```
 $ ssh admin@blackhole.ocf.berkeley.edu
 Password:
-blackhole.ocf.berkeley.edu>  
+blackhole.ocf.berkeley.edu>
 ```
 
 The switches can also be administered directly by connecting to their console port
@@ -74,7 +74,7 @@ Port Channel Port-Channel5:
 Port Channel Port-Channel7:
   No Active Ports
   Configured, but inactive ports:
-       Port          Reason unconfigured  
+       Port          Reason unconfigured
     ---------------- -------------------------
        Ethernet13    Waiting for LACP response
        Ethernet14    Waiting for LACP response

--- a/ocfweb/docs/docs/staff/tips/shorturls.md
+++ b/ocfweb/docs/docs/staff/tips/shorturls.md
@@ -10,7 +10,7 @@ We've additionally defined other shorturls. Here are some especially useful
 ones for staff:
 
  * **ocf.io/gh/_<repo>_**, **ocf.io/github/_<repo>_**: The repository _<repo>_
-   on the OCF GitHub page.  
+   on the OCF GitHub page.\
    There are also abbreviations for the most commonly used repositories:
     * **ocf.io/gh/i**: ircbot
     * **ocf.io/gh/l**: ocflib

--- a/tests/component/markdown_test.py
+++ b/tests/component/markdown_test.py
@@ -38,6 +38,24 @@ def test_simple_markdown():
     )
 
 
+def test_backslash_linebreak():
+    assert_markdown(
+        '''\
+            this is some paragraph text\\
+            with a line break \\ and an escaped backslash
+
+            * And a list\\
+              with a newline in it
+        ''',
+        '''\
+            <p>this is some paragraph text<br>with a line break \\ and an escaped backslash</p>
+            <ul>
+            <li>And a list<br>with a newline in it</li>
+            </ul>
+        '''
+    )
+
+
 def test_comments_get_stripped():
     assert_markdown(
         '''\


### PR DESCRIPTION
I think the added test and docstring explain what this does pretty well, as well as the [GFM docs](https://github.github.com/gfm/#backslash-escapes) on this. Basically, I added this because a lot of editors people have (mine included) strip trailing whitespace, but it's actually used in markdown for hard line breaks (`<br>` tags), which is unfortunate. Now, with this change, adding a backslash before the newline at the end of a line will add in a line break (just like adding two spaces before the newline did before), but backslashes in the middle of a line will just function as normal.

Thoughts?

I also removed some of the duplication with the HTML comment mixins, since they can just share a class as far as I can tell for both inline and block lexers.

As a side note, backslash escaping with regexes is really annoying, because they need to be escaped in python and also escaped for the regex parser, and using a raw string in this case doesn't work because it contains a literal newline. That took a while to mess around with and figure out anyway.