### PR TITLE
Use new hours2 library

### DIFF
--- a/ocfweb/api/hours.py
+++ b/ocfweb/api/hours.py
@@ -1,149 +1,34 @@
-import operator
-from collections import namedtuple
-from datetime import date
-from datetime import datetime
-from datetime import timedelta
+from datetime import time
+from json import JSONEncoder
 
-import requests
 from django.http import JsonResponse
+from ocflib.lab.hours2 import Hour
+from ocflib.lab.hours2 import HoursListing
+from ocflib.lab.hours2 import read_hours_listing
 
 from ocfweb.caching import periodic
 
-HOURS_SPREADSHEET = 'https://docs.google.com/spreadsheet/ccc?key=1FHgW0wCnAh49bZIw54eoBT9xEoJ3AGG7Y2LhQdi0Lvs&output=csv'  # noqa: E501
-SHIFT_LENGTH = timedelta(hours=1)
 
-
-class Hour(namedtuple('Hours', ['open', 'close', 'staffer'])):
-
-    def __contains__(self, when):
-        if isinstance(when, datetime):
-            when = when.time()
-
-        return self.open <= when < self.close
-
-
-def _get_hours():
-    """pull hours from the Google spreadsheet and parse shifts."""
-
-    response = requests.get(HOURS_SPREADSHEET)
-    response.raise_for_status()
-
-    matrix = response.text.splitlines()
-    matrix = [row.split(',') for row in matrix]
-
-    # row[0] = ['13:30PM', 'name1', 'name2', ...]
-    shifts = [row[0] for row in matrix]
-
-    # first row is a header, first col is times: ['', 'Monday', ...]
-    header = shifts.pop(0)
-    assert header == '', header
-
-    all_shifts = {}
-
-    # instead of e.g. enumerate(['Monday', 'Tuesday', ... 'Sunday'])
-    for day in range(7):
-        # matrix[sidx + 1][day + 1] = person on shift on that shift index
-        all_shifts[day] = {
-            shift: matrix[sidx + 1][day + 1] for sidx, shift in enumerate(shifts)
-        }
-
-    #  this will get cached downstream
-    return all_shifts
-
-
-def _merge_shifts(first, second, staffer=True):
-    return Hour(
-        open=min(first.open, second.open),
-        close=max(first.close, second.close),
-        staffer=first.staffer if staffer else None,
-    )
-
-
-def _combine_shifts(shifts):
-    """combine a list of shifts into a list of Hour()s.
-
-    >>> _combine_shifts({'16:00PM':'test1', '16:30PM':'test2', ...})
-    [Hour(open=time(16), close=time(17), staffer='test2'), ...]
-    """
-
-    raw_shifts = []
-    for shift, staffer in shifts.items():
-        if not staffer:  # skip unstaffed shifts
-            continue
-
-        open = datetime.strptime(shift, '%I:%M %p')  # 12-hour AM/PM i.e. 7:00PM
-        close = open + SHIFT_LENGTH
-        raw_shifts.append(Hour(open=open.time(), close=close.time(), staffer=staffer))
-
-    raw_shifts.sort(key=operator.attrgetter('open'))
-
-    combined_shifts = []
-
-    shift = raw_shifts.pop(0)
-    for next_shift in raw_shifts:
-        if (shift.close in next_shift or next_shift.close in shift) and \
-                shift.staffer == next_shift.staffer:
-            shift = _merge_shifts(shift, next_shift)
+class JSONHoursEncoder(JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, HoursListing):
+            return obj.__dict__
+        elif isinstance(obj, Hour):
+            return [obj.open, obj.close]
+        elif isinstance(obj, time):
+            return obj.strftime('%H:%M:%S')
         else:
-            combined_shifts.append(shift)
-            shift = next_shift
-
-    # tail case where staffer condition doesn't trip on list end
-    combined_shifts.append(shift)
-
-    return combined_shifts
+            return JSONEncoder.default(self, obj)
 
 
-def _generate_regular_hours():
-    raw_hours = _get_hours()
-    return {day: _combine_shifts(shifts) for day, shifts in raw_hours.items()}
-
-
-@periodic(5 * 60)
-def display_hours():
-    """merge shifts even further for display.
-
-    ocflib previously provided a list of hours separated when there
-    were discontinuous shifts. This hours implementation separates
-    hours when different opstaff are on shift as well for future big
-    brother tracking purposes, but this breaks applications that depend on
-    a concise list of hours for display. This is a fix that presents hours
-    like the old implementation until the code can be refactored as part
-    of the overall big brother project, i.e., in ocflib.
-    """
-
-    regular_hours = _generate_regular_hours()
-
-    display_hours = {}
-
-    for day, hours in regular_hours.items():
-        merged_shifts = []
-
-        hour = hours.pop(0)
-        for next_hour in hours:
-            if hour.close in next_hour or next_hour.close in hour:
-                hour = _merge_shifts(hour, next_hour, False)
-            else:
-                merged_shifts.append(hour)
-                hour = next_hour
-
-        merged_shifts.append(hour)
-
-        display_hours[day] = merged_shifts
-
-    return display_hours
-
-
-def get_hours_all(request):
-    return JsonResponse(
-        display_hours(),
-        json_dumps_params={'default': lambda x: x.isoformat()},
-    )
+@periodic(60)
+def get_hours_listing():
+    return read_hours_listing()
 
 
 def get_hours_today(request):
     return JsonResponse(
-        display_hours()[date.today().weekday()],
-        json_dumps_params={'default': lambda x: x.isoformat()},
+        get_hours_listing().hours_on_date(),
+        encoder=JSONHoursEncoder,
         safe=False,
     )

--- a/ocfweb/api/urls.py
+++ b/ocfweb/api/urls.py
@@ -5,7 +5,6 @@ from ocfweb.api import lab
 from ocfweb.api import session_tracking
 
 urlpatterns = [
-    path('hours', hours.get_hours_all, name='hours_all'),
     path('hours/today', hours.get_hours_today, name='hours_today'),
     path('lab/desktops', lab.desktop_usage, name='desktop_usage'),
     path('session/log', session_tracking.log_session, name='log_session'),

--- a/ocfweb/context_processors.py
+++ b/ocfweb/context_processors.py
@@ -1,13 +1,12 @@
 import re
-from datetime import date
 from ipaddress import ip_address
 
 from django.urls import reverse
 from ipware import get_client_ip
 from ocflib.account.search import user_is_group
 from ocflib.infra.net import is_ocf_ip
-from ocflib.lab.hours import Day
 
+from ocfweb.api.hours import get_hours_listing
 from ocfweb.component.lab_status import get_lab_status
 from ocfweb.component.session import logged_in_user
 from ocfweb.environment import ocfweb_version
@@ -24,15 +23,16 @@ def get_base_css_classes(request):
 
 
 def ocf_template_processor(request):
-    hours = Day.from_date(date.today())
+    hours_listing = get_hours_listing()
     real_ip, _ = get_client_ip(request)
     user = logged_in_user(request)
     return {
         'base_css_classes': ' '.join(get_base_css_classes(request)),
-        'current_lab_hours': hours,
+        'current_lab_hours': hours_listing.hours_on_date(),
+        'holidays': hours_listing.holidays,
         'is_ocf_ip': is_ocf_ip(ip_address(real_ip)) if real_ip else True,
         'join_staff_url': request.build_absolute_uri(reverse('about-staff')),
-        'lab_is_open': hours.is_open(),
+        'lab_is_open': hours_listing.is_open(),
         'lab_status': get_lab_status(),
         'ocfweb_version': ocfweb_version(),
         'request_full_path': request.get_full_path(),

--- a/ocfweb/docs/templates/docs/lab.html
+++ b/ocfweb/docs/templates/docs/lab.html
@@ -57,13 +57,15 @@
                 <div class="row">
                     <div class="col-sm-12">
                         <table class="table table-striped table-hover">
-                            {% for hour in hours_this_week %}
+                            {% for hours_date, hours in hours_this_week %}
                                 <tr>
                                     <th>
-                                        {{hour.weekday}},
-                                        {{hour.date | date:'M d'}}
+                                        {{hours_date | date:'l, M d'}}
                                     </th>
-                                    <td>{{hour.hours | lab_hours_time}} {{hour | lab_hours_holiday}}</td>
+                                    <td>
+                                        {{hours | lab_hours_time}}
+                                        {% lab_hours_holiday holidays hours_date %}
+                                    </td>
                                 </tr>
                             {% endfor %}
                         </table>
@@ -76,13 +78,14 @@
                 <div class="row">
                     <div class="col-sm-12">
                         <table class="table table-striped table-hover">
-                            <tr><th>Sunday</th><td>{{regular_hours | getitem:SUNDAY | lab_hours_time}}</td></tr>
-                            <tr><th>Monday</th><td>{{regular_hours | getitem:MONDAY | lab_hours_time}}</td></tr>
-                            <tr><th>Tuesday</th><td>{{regular_hours | getitem:TUESDAY | lab_hours_time}}</td></tr>
-                            <tr><th>Wednesday</th><td>{{regular_hours | getitem:WEDNESDAY | lab_hours_time}}</td></tr>
-                            <tr><th>Thursday</th><td>{{regular_hours | getitem:THURSDAY | lab_hours_time}}</td></tr>
-                            <tr><th>Friday</th><td>{{regular_hours | getitem:FRIDAY | lab_hours_time}}</td></tr>
-                            <tr><th>Saturday</th><td>{{regular_hours | getitem:SATURDAY | lab_hours_time}}</td></tr>
+                            {% comment %} Monday is the 0th weekday {% endcomment %}
+                            <tr><th>Sunday</th><td>{{regular_hours | getitem:6 | lab_hours_time}}</td></tr>
+                            <tr><th>Monday</th><td>{{regular_hours | getitem:0 | lab_hours_time}}</td></tr>
+                            <tr><th>Tuesday</th><td>{{regular_hours | getitem:1 | lab_hours_time}}</td></tr>
+                            <tr><th>Wednesday</th><td>{{regular_hours | getitem:2 | lab_hours_time}}</td></tr>
+                            <tr><th>Thursday</th><td>{{regular_hours | getitem:3 | lab_hours_time}}</td></tr>
+                            <tr><th>Friday</th><td>{{regular_hours | getitem:4 | lab_hours_time}}</td></tr>
+                            <tr><th>Saturday</th><td>{{regular_hours | getitem:5 | lab_hours_time}}</td></tr>
                         </table>
                     </div>
                 </div>
@@ -97,15 +100,15 @@
                     <div class="row">
                         <div class="col-sm-12">
                             <table class="table table-striped table-hover">
-                                {% for start, stop, name, hours in holidays %}
+                                {% for holiday in holidays %}
                                     <tr>
-                                        {% if start == stop %}
-                                            <th>{{start | date:holiday_format}}</th>
+                                        {% if holiday.startdate == holiday.enddate %}
+                                            <th>{{holiday.startdate | date:holiday_format}}</th>
                                         {% else %}
-                                            <th>{{start | date:holiday_format}} &mdash; {{stop | date:holiday_format}}</th>
+                                            <th>{{holiday.startdate | date:holiday_format}} &mdash; {{holiday.enddate | date:holiday_format}}</th>
                                         {% endif %}
-                                        <td>{{name}}</td>
-                                        <td>{{hours | lab_hours_time}}</td>
+                                        <td>{{holiday.reason}}</td>
+                                        <td>{{holiday.hours | lab_hours_time}}</td>
                                     </tr>
                                 {% endfor %}
                             </table>

--- a/ocfweb/main/home.py
+++ b/ocfweb/main/home.py
@@ -3,10 +3,10 @@ from datetime import timedelta
 from operator import attrgetter
 
 from django.shortcuts import render
-from ocflib.lab.hours import Day
 from ocflib.lab.staff_hours import get_staff_hours_soonest_first
 
 from ocfweb.announcements.announcements import announcements
+from ocfweb.api.hours import get_hours_listing
 from ocfweb.caching import periodic
 from ocfweb.component.blog import get_blog_posts
 from ocfweb.component.lab_status import get_lab_status
@@ -18,7 +18,14 @@ def get_staff_hours():
 
 
 def home(request):
-    hours = [Day.from_date(date.today() + timedelta(days=i)) for i in range(3)]
+    hours_listing = get_hours_listing()
+    hours = [
+        (
+            date.today() + timedelta(days=i),
+            hours_listing.hours_on_date(date.today() + timedelta(days=i)),
+        )
+        for i in range(3)
+    ]
     return render(
         request,
         'main/home.html',

--- a/ocfweb/main/templates/main/home.html
+++ b/ocfweb/main/templates/main/home.html
@@ -78,19 +78,17 @@
 
         <p><strong>Upcoming Lab Hours</strong></p>
         <div class="ocf-hours">
-            {% for hour in hours %}
+            {% for hours_date, hour in hours %}
                 <div class="ocf-hour row {% cycle 'odd' 'even' %}">
                     <div class="col-sm-5 col-md-3 ocf-hour-title">
-                        {{hour.weekday}}<br />
+                        {{hours_date | date:'l'}}<br />
                     </div>
                     <div class="col-sm-7 col-md-9 ocf-hour-hours">
                         {% if hour == today and lab_status.force_lab_closed %}
                             Temporarily Closed
                         {% else %}
-                            {{hour.hours | lab_hours_time}}
-                            {% if hour.holiday %}
-                                ({{hour.holiday}})
-                            {% endif %}
+                            {{hour | lab_hours_time}}
+                            {% lab_hours_holiday holidays hours_date %}
                         {% endif %}
                     </div>
                 </div>

--- a/ocfweb/stats/daily_graph.py
+++ b/ocfweb/stats/daily_graph.py
@@ -8,11 +8,10 @@ from django.shortcuts import redirect
 from django.urls import reverse
 from matplotlib.dates import DateFormatter
 from matplotlib.figure import Figure
-from ocflib.lab.hours import Day
 from ocflib.lab.stats import list_desktops
 from ocflib.lab.stats import UtilizationProfile
 
-from ocfweb.api.hours import display_hours
+from ocfweb.api.hours import get_hours_listing
 from ocfweb.caching import periodic
 from ocfweb.component.graph import plot_to_image_bytes
 
@@ -57,24 +56,24 @@ def get_open_close(day):
 
     If the lab is closed all day (e.g. holiday), just return our weekday hours.
     """
-    d = Day.from_date(day)
-    regular_hours = display_hours()
+    hours_listing = get_hours_listing()
+    d = hours_listing.hours_on_date()
 
-    if not d.closed_all_day:
-        start = datetime(day.year, day.month, day.day, min(h.open.hour for h in d.hours))
-        end = datetime(day.year, day.month, day.day, max(h.close.hour for h in d.hours))
+    if d:
+        start = datetime(day.year, day.month, day.day, min(h.open.hour for h in d))
+        end = datetime(day.year, day.month, day.day, max(h.close.hour for h in d))
     else:
         start = datetime(
             day.year,
             day.month,
             day.day,
-            min(h.open.hour for hour_list in regular_hours.values() for h in hour_list),
+            min(h.open.hour for hour_list in hours_listing.regular.values() for h in hour_list),
         )
         end = datetime(
             day.year,
             day.month,
             day.day,
-            max(h.close.hour for hour_list in regular_hours.values() for h in hour_list),
+            max(h.close.hour for hour_list in hours_listing.regular.values() for h in hour_list),
         )
 
     return start, end

--- a/ocfweb/templates/base.html
+++ b/ocfweb/templates/base.html
@@ -107,11 +107,11 @@
                             <strong>Lab Currently Closed</strong>
                         {% endif %}
                         <span class="nowrap">
-                            {% if not lab_is_open and not current_lab_hours.closed_all_day %}
+                            {% if not lab_is_open and current_lab_hours %}
                                 Hours:
                             {% endif %}
-                            {{current_lab_hours.hours|lab_hours_time}}
-                            on {{current_lab_hours.weekday}} {{current_lab_hours | lab_hours_holiday}}
+                            {{current_lab_hours|lab_hours_time}}
+                            on {% now "l" %} {% lab_hours_holiday holidays %}
                             <a class="subtle" href="{% url 'doc' 'services/lab' %}">more &raquo;</a>
                         </span>
                     {% else %}

--- a/ocfweb/templatetags/lab_hours.py
+++ b/ocfweb/templatetags/lab_hours.py
@@ -1,12 +1,18 @@
+from datetime import date
+
 from django import template
 
 register = template.Library()
 
 
-@register.filter
-def lab_hours_holiday(hours):
-    if hours.holiday:
-        return '({})'.format(hours.holiday)
+@register.simple_tag
+def lab_hours_holiday(holidays, when=None):
+    if when is None:
+        when = date.today()
+
+    for holiday in holidays:
+        if holiday.startdate <= when <= holiday.enddate:
+            return '({})'.format(holiday.reason)
     return ''
 
 


### PR DESCRIPTION
Next part of the great migration. This migrates ocfweb to use the new hours API.

I've mostly tested this, but there could be some tricky edge cases that I missed.