### PR TITLE
web: pass upstream HTTP headers to django

### DIFF
--- a/services/web/nginx/nginx.conf
+++ b/services/web/nginx/nginx.conf
@@ -34,6 +34,7 @@ http {
           proxy_set_header X-Forwarded-Proto $scheme;
           proxy_set_header Host $http_host;
           proxy_redirect   off;
+          proxy_pass_request_headers on;
           proxy_pass       http://ocfweb;
 
           location /api {


### PR DESCRIPTION
Resolves #463. This should pass in upstream headers from Apache.