### PR TITLE
Add links to the staff recruitment page

### DIFF
--- a/ocfweb/about/templates/about/staff.html
+++ b/ocfweb/about/templates/about/staff.html
@@ -25,13 +25,17 @@
                 <div class="col-sm-6">
                     <h2>Join us at our weekly meetings!</h2>
                     <p>
-                        We meet every week to talk tech and make decisions.
-                        During the first meeting, we'll spend time talking about
-                        what the OCF is and why it's awesome.
+                        We meet every week to talk tech and work on cool projects.
+                        All are welcome to join OCF staff, at any point in the semester!
                     </p>
                     <p>
                         <strong style="font-size: 18px;">Sound interesting?</strong><br />
-                        Drop by and say hello, or <a href="{% url 'doc' 'contact' %}">get in touch</a>!
+                        <ul>
+                            <li>Subscribe to our <a href="https://ocf.io/announce">mailing list</a> for meeting recaps</li>
+                            <li>Chat with us on <a href="{% url 'doc' 'contact/slack' %}">Slack</a> or <a href="{% url 'doc' 'contact/irc'%}">IRC</a></li>
+                            <li>Drop by and say hello, or <a href="{% url 'doc' 'contact' %}">email the staff team</a></li>
+                            <li>See more ways to <a href="{% url 'doc' 'staff/getinvolved' %}">contribute and get involved</a></li>
+                        </ul>
                     </p>
                 </div>
                 <div class="col-sm-6">


### PR DESCRIPTION
Usually when people ask for ways to get involved, I point them to the mailing list and get involved pages. These should be on our "official" recruitment page. I've updated it to fit in with what we usually tell new staffers.
![2019-03-15-160802_1199x258_scrot](https://user-images.githubusercontent.com/749522/54467232-0c850000-4741-11e9-9e67-b20074fafe87.png)
