### PR TITLE
Correct OCF physical address

### DIFF
--- a/ocfweb/docs/docs/contact.md
+++ b/ocfweb/docs/docs/contact.md
@@ -64,9 +64,9 @@ to ever be read.
 Our address is:
 
     Open Computing Facility
-    171 MLK Student Union MC#4520
+    2495 Bancroft Ave Ste. 171
     University of California, Berkeley
-    Berkeley, CA 94720
+    Berkeley, CA 94720-4520
 
 ## Legal
 


### PR DESCRIPTION
Based on the Spring 2019 MLK Town Hall slides, and from UPS vendor feedback. We were using outdated mailing address.