### PR TITLE
Mypy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /ocflib
 
 ## generic python stuff below
+.mypy_cache/
 __pycache__/
 *.py[cod]
 *$py.class

--- a/Makefile
+++ b/Makefile
@@ -14,12 +14,16 @@ DOCKER_TAG_STATIC = $(DOCKER_REPO)ocfweb-static:$(DOCKER_REVISION)
 # after running tests
 .PHONY: test
 test: export OCFWEB_TESTING ?= 1
-test: venv
+test: venv mypy
 	$(BIN)/py.test -v tests/
 	$(BIN)/pre-commit run --all-files
 ifneq ($(strip $(COVERALLS_REPO_TOKEN)),)
 	$(BIN)/coveralls
 endif
+
+.PHONY: mypy
+mypy: venv
+	$(BIN)/mypy -p ocfweb
 
 .PHONY: Dockerfile.%
 Dockerfile.%: Dockerfile.%.in

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ ocfweb
 [![Build Status](https://jenkins.ocf.berkeley.edu/buildStatus/icon?job=ocfweb/master)](https://jenkins.ocf.berkeley.edu/job/ocfweb/job/master/)
 [![Coverage Status](https://coveralls.io/repos/github/ocf/ocfweb/badge.svg?branch=master)](https://coveralls.io/github/ocf/ocfweb?branch=master)
 [![Code Health](https://landscape.io/github/ocf/ocfweb/master/landscape.svg?style=flat)](https://landscape.io/github/ocf/ocfweb/master)
+[![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
 
 [The main ocf website.](https://www.ocf.berkeley.edu/)
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,5 @@
+[mypy]
+show_traceback = True
+ignore_missing_imports = True
+plugins =
+    mypy_django_plugin.main

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,5 @@
 [mypy]
+# TODO: enable more flags like in https://github.com/ocf/slackbridge/blob/master/mypy.ini
 show_traceback = True
 ignore_missing_imports = True
 plugins =

--- a/mypy_django.ini
+++ b/mypy_django.ini
@@ -1,0 +1,9 @@
+[mypy_django_plugin]
+# the location of our settings module
+django_settings = ocfweb.settings
+
+# if we can't find settings, make them Any
+ignore_missing_settings = False
+
+# allow unknown attributes on Models
+ignore_missing_model_attributes = True

--- a/ocfweb/account/register.py
+++ b/ocfweb/account/register.py
@@ -4,7 +4,7 @@ import ocflib.misc.validators
 import ocflib.ucb.directory as directory
 from Crypto.PublicKey import RSA
 from django import forms
-from django.forms.forms import NON_FIELD_ERRORS
+from django.core.exceptions import NON_FIELD_ERRORS
 from django.http import HttpResponseBadRequest
 from django.http import HttpResponseRedirect
 from django.http import JsonResponse

--- a/ocfweb/announcements/announcements.py
+++ b/ocfweb/announcements/announcements.py
@@ -11,7 +11,9 @@ from django.utils import timezone
 
 from ocfweb.component.blog import get_blog_posts
 
-announcements = ()
+from typing import Tuple
+
+announcements: Tuple['Announcement', ...] = ()
 
 
 class Announcement(namedtuple('Announcement', ('title', 'date', 'path', 'render'))):

--- a/ocfweb/announcements/announcements.py
+++ b/ocfweb/announcements/announcements.py
@@ -2,6 +2,7 @@ from collections import namedtuple
 from datetime import date
 from datetime import datetime
 from datetime import time
+from typing import Tuple
 
 from cached_property import cached_property
 from django.shortcuts import render
@@ -10,8 +11,6 @@ from django.urls import reverse
 from django.utils import timezone
 
 from ocfweb.component.blog import get_blog_posts
-
-from typing import Tuple
 
 announcements: Tuple['Announcement', ...] = ()
 

--- a/ocfweb/docs/views/commands.py
+++ b/ocfweb/docs/views/commands.py
@@ -1,8 +1,8 @@
-from collections import namedtuple
+from typing import NamedTuple
+from typing import Optional
 
 from django.shortcuts import render
 
-from typing import NamedTuple, Optional
 
 class Command(NamedTuple):
     name: str
@@ -10,6 +10,7 @@ class Command(NamedTuple):
     desc: str
     doc: Optional[str] = None
     doc_anchor: Optional[str] = None
+
 
 OCF_COMMANDS = [
     Command(

--- a/ocfweb/docs/views/commands.py
+++ b/ocfweb/docs/views/commands.py
@@ -2,11 +2,14 @@ from collections import namedtuple
 
 from django.shortcuts import render
 
+from typing import NamedTuple, Optional
 
-Command = namedtuple('Command', ['name', 'args', 'desc', 'doc', 'doc_anchor'])
-# Default last two fields to None
-Command.__new__.__defaults__ = (None, None)
-
+class Command(NamedTuple):
+    name: str
+    args: Optional[str]
+    desc: str
+    doc: Optional[str] = None
+    doc_anchor: Optional[str] = None
 
 OCF_COMMANDS = [
     Command(

--- a/ocfweb/settings.py
+++ b/ocfweb/settings.py
@@ -4,9 +4,10 @@ import socket
 import tempfile
 import warnings
 
-from django.core.cache import CacheKeyWarning
-from django.template.base import TemplateSyntaxError
+from django.core.cache.backends.base import CacheKeyWarning
+from django.template.exceptions import TemplateSyntaxError
 
+from typing import Dict, Any
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 TESTING = os.environ.get('OCFWEB_TESTING') == '1'
@@ -88,7 +89,6 @@ TEMPLATES = [{
 
 WSGI_APPLICATION = 'ocfweb.wsgi.application'
 
-DATABASES = {}
 
 # store sessions in the cache
 SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
@@ -104,7 +104,7 @@ SESSION_COOKIE_HTTPONLY = True
 SESSION_COOKIE_PATH = '/'
 SESSION_COOKIE_NAME = 'OCFWEB_SESSIONID'
 
-CACHES = {  # sessions are stored here
+CACHES: Dict[str, Any] = {  # sessions are stored here
     'TIMEOUT': 60 * 60 * 12,  # 12 hours
     'OPTIONS': {
         'MAX_ENTRIES': 1000,

--- a/ocfweb/settings.py
+++ b/ocfweb/settings.py
@@ -3,11 +3,11 @@ import os
 import socket
 import tempfile
 import warnings
+from typing import Any
+from typing import Dict
 
 from django.core.cache.backends.base import CacheKeyWarning
 from django.template.exceptions import TemplateSyntaxError
-
-from typing import Dict, Any
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 TESTING = os.environ.get('OCFWEB_TESTING') == '1'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,8 +4,8 @@ atomicwrites==1.3.0
 cfgv==1.6.0
 coverage==4.5.3
 coveralls==1.7.0
-docopt==0.6.2
 django-stubs==0.12.1
+docopt==0.6.2
 execnet==1.6.0
 identify==1.4.1
 importlib-metadata==0.9

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,11 +5,13 @@ cfgv==1.6.0
 coverage==4.5.3
 coveralls==1.7.0
 docopt==0.6.2
+django-stubs==0.12.1
 execnet==1.6.0
 identify==1.4.1
 importlib-metadata==0.9
 importlib-resources==1.0.2
 more-itertools==7.0.0
+mypy==0.701
 nodeenv==1.3.3
 pathlib2==2.3.3
 pluggy==0.9.0


### PR DESCRIPTION
This is the bare minimum for running mypy on ocfweb.

Ideally the type checking could be made stricter by enabling flags such as those found in https://github.com/ocf/slackbridge/blob/master/mypy.ini