### PR TITLE
staffdocs: add case:yes to sourcegraph-todo link in getinvolved

### DIFF
--- a/ocfweb/docs/docs/staff/getinvolved.md
+++ b/ocfweb/docs/docs/staff/getinvolved.md
@@ -244,7 +244,7 @@ community.
 [slack]: https://ocf.io/slack
 [slackbridge/issues]: https://github.com/ocf/slackbridge/issues
 [slackbridge]: https://github.com/ocf/slackbridge
-[sourcegraph-todo]: https://sourcegraph.ocf.berkeley.edu/search?q=TODO
+[sourcegraph-todo]: https://sourcegraph.ocf.berkeley.edu/search?q=TODO+case:yes
 [staffhours]: https://ocf.io/staffhours
 [utils-acct]: https://github.com/ocf/utils/tree/master/acct
 [utils-lab-wakeup]: https://github.com/ocf/utils/blob/master/staff/lab/lab-wakeup


### PR DESCRIPTION
This search will sometimes show parts of our code that just happen to say "todo". Enabling case on this search will eliminate some of these, since actual todo's will always be in all caps.