### PR TITLE
Change get_lab_status() to read from ocf's etc repo.

### DIFF
--- a/ocfweb/component/lab_status.py
+++ b/ocfweb/component/lab_status.py
@@ -1,6 +1,5 @@
 from collections import namedtuple
 
-import requests
 import yaml
 
 from ocfweb.caching import periodic
@@ -17,15 +16,8 @@ LabStatus = namedtuple(
 @periodic(60, ttl=86400)
 def get_lab_status():
     """Get the front page banner message from the default location."""
-    try:
-        with open('/home/s/st/staff/lab_status.yaml') as f:
-            tree = yaml.safe_load(f)
-    except IOError:
-        tree = yaml.safe_load(
-            requests.get(
-                'https://www.ocf.berkeley.edu/~staff/lab_status.yaml',
-            ).text,
-        )
+    with open('/etc/ocf/lab_status.yaml') as f:
+        tree = yaml.safe_load(f)
     return LabStatus(
         force_lab_closed=tree['force_lab_closed'],
         banner_html=tree['banner_html'] if tree['banner_visible'] else '',


### PR DESCRIPTION
In the future we should probably move the banner's HTML and CSS to within ocfweb and have the yaml file specify the text.