### PR TITLE
Add Staff Hours to API

### DIFF
--- a/ocfweb/api/staff_hours.py
+++ b/ocfweb/api/staff_hours.py
@@ -1,0 +1,13 @@
+from json import JSONEncoder
+
+from django.http import JsonResponse
+
+from ocfweb.main.staff_hours import get_staff_hours as real_get_staff_hours
+
+
+def get_staff_hours(request):
+    return JsonResponse(
+        list(map(lambda item: item._asdict(), real_get_staff_hours())),
+        encoder=JSONEncoder,
+        safe=False,
+    )

--- a/ocfweb/api/staff_hours.py
+++ b/ocfweb/api/staff_hours.py
@@ -1,5 +1,3 @@
-from json import JSONEncoder
-
 from django.http import JsonResponse
 
 from ocfweb.main.staff_hours import get_staff_hours as real_get_staff_hours
@@ -7,7 +5,6 @@ from ocfweb.main.staff_hours import get_staff_hours as real_get_staff_hours
 
 def get_staff_hours(request):
     return JsonResponse(
-        list(map(lambda item: item._asdict(), real_get_staff_hours())),
-        encoder=JSONEncoder,
+        [item._asdict() for item in real_get_staff_hours()],
         safe=False,
     )

--- a/ocfweb/api/urls.py
+++ b/ocfweb/api/urls.py
@@ -4,9 +4,11 @@ from ocfweb.api import hours
 from ocfweb.api import lab
 from ocfweb.api import session_tracking
 from ocfweb.api import shorturls
+from ocfweb.api import staff_hours
 
 
 urlpatterns = [
+    path('hours/staff', staff_hours.get_staff_hours, name='staff_hours'),
     path('hours/today', hours.get_hours_today, name='hours_today'),
     path('lab/desktops', lab.desktop_usage, name='desktop_usage'),
     path('session/log', session_tracking.log_session, name='log_session'),


### PR DESCRIPTION
Exposes our staff hours to the API. Uses the existing cached function.