### PR TITLE
staffdocs: make command for adding new staff less verbose

### DIFF
--- a/ocfweb/docs/docs/staff/procedures/granting-privileges.md
+++ b/ocfweb/docs/docs/staff/procedures/granting-privileges.md
@@ -10,7 +10,7 @@ editing the group in LDAP:
 ```text
 $ kinit you/admin
 you/admin@OCF.BERKELEY.EDU's Password:
-$ ldapvi '(cn=ocfstaff)'
+$ ldapvi cn=ocfstaff
 ```
 
 Then add or remove the appropriate `memberUid` attribute.


### PR DESCRIPTION
the parens and quotes here aren't necessary, this makes it easier to type