### PR TITLE
Fix 500 Error on stats/printing

### DIFF
--- a/ocfweb/stats/printing.py
+++ b/ocfweb/stats/printing.py
@@ -162,11 +162,6 @@ def _pages_per_day():
                 )
             last_seen[row['printer']] = row['value']
 
-    # # Fix missing rows in table (if data collection failed)
-    # for day in (date.today() - timedelta(n) for n in range(30)):
-    #     if day not in pages_printed.keys():
-    #     pages_printed[day] = defaultdict(int)
-
     return pages_printed
 
 

--- a/ocfweb/stats/printing.py
+++ b/ocfweb/stats/printing.py
@@ -153,7 +153,6 @@ def _pages_per_day():
 
         last_seen = {}
         pages_printed = {}
-
         for row in cursor:
             if row['printer'] in last_seen:
                 pages_printed.setdefault(row['date'], defaultdict(int))
@@ -161,6 +160,11 @@ def _pages_per_day():
                     row['value'] - last_seen[row['printer']]
                 )
             last_seen[row['printer']] = row['value']
+
+    # Fix missing rows in table (if data collection failed)
+    for day in (date.today() - timedelta(n) for n in range(30)):
+        if day not in pages_printed.keys():
+            pages_printed[day] = defaultdict(int)
 
     return pages_printed
 

--- a/ocfweb/stats/printing.py
+++ b/ocfweb/stats/printing.py
@@ -2,6 +2,7 @@ import time
 from collections import defaultdict
 from datetime import date
 from datetime import timedelta
+from functools import partial
 
 from django.http import HttpResponse
 from django.shortcuts import render
@@ -152,7 +153,7 @@ def _pages_per_day():
         ''')
 
         last_seen = {}
-        pages_printed = {}
+        pages_printed = pages_printed = defaultdict(partial(defaultdict, int))
         for row in cursor:
             if row['printer'] in last_seen:
                 pages_printed.setdefault(row['date'], defaultdict(int))
@@ -161,10 +162,10 @@ def _pages_per_day():
                 )
             last_seen[row['printer']] = row['value']
 
-    # Fix missing rows in table (if data collection failed)
-    for day in (date.today() - timedelta(n) for n in range(30)):
-        if day not in pages_printed.keys():
-            pages_printed[day] = defaultdict(int)
+    # # Fix missing rows in table (if data collection failed)
+    # for day in (date.today() - timedelta(n) for n in range(30)):
+    #     if day not in pages_printed.keys():
+    #     pages_printed[day] = defaultdict(int)
 
     return pages_printed
 

--- a/ocfweb/stats/printing.py
+++ b/ocfweb/stats/printing.py
@@ -152,8 +152,12 @@ def _pages_per_day():
                 ORDER BY date ASC, printer ASC
         ''')
 
+        # Resolves the issue of possible missing dates.
+        # defaultdict(lambda: defaultdict(int)) doesn't work due to inability to pickle local objects like lambdas;
+        # this effectively does the same thing as that.
+        pages_printed = defaultdict(partial(defaultdict, int))
         last_seen = {}
-        pages_printed = pages_printed = defaultdict(partial(defaultdict, int))
+
         for row in cursor:
             if row['printer'] in last_seen:
                 pages_printed.setdefault(row['date'], defaultdict(int))


### PR DESCRIPTION
Due to the power outage, no data was collected on 2019/10/10, so ocf.io/stats/printing would throw a KeyError when trying to display the missing data.

I added this to fill in the blanks for the last month's worth of data in case another power outage / server issue happens again.
```python
    # Fix missing rows in table (if data collection failed)
    for day in (date.today() - timedelta(n) for n in range(30)):
        if day not in pages_printed.keys():
            pages_printed[day] = defaultdict(int)
```

Now all the tests pass again :D