### PR TITLE
Added account.md

### DIFF
--- a/ocfweb/docs/templates/docs/partials/account.md
+++ b/ocfweb/docs/templates/docs/partials/account.md
@@ -1,0 +1,37 @@
+What Your OCF Account Gets You
+
+Many think of the Open Computing Facility as an on-campus resource for free printing. While this is true, and printing is certainly our most-demanded service (we print hundreds of thousands of pages per year), there are plenty of other great services provided by the OCF, which come free with your account!
+
+## Free Computing
+
+The OCF was founded to provide all members of the Cal campus community with computing resources. Anytime we're open, all members of the community are welcome to use the computers for any reason – not just to print. All of the computers in the OCF run Linux as the operating system and have a variety of useful (although potentially unfamiliar) applications installed. Because of our committment to free, open-source software, we do not provide access to application suites such as Microsoft Office or Adobe Creative Cloud; instead, we provide free alternatives.
+* Google Chrome, Firefox, and Brave are all installed, allowing users to choose their preferred web browser.
+* The LibreOffice suite is installed as an alternative to Microsoft Office. It is mostly cross-compatible with Office files, meaning one can import or export .docx/.pptx/.xlsx files. Users can also use Google Docs from a web browser.
+* GIMP (GNU Image Manipulation Program) is provided as an alternative to Adobe Photoshop, and Inkscape replaces Adobe Illustrator. For animation and 3D modeling, we provide access to Blender.
+* Rather than iTunes/QuickTime or Windows Media Player, users can access music or video files using VLC.
+* The pre-installed text editor is Atom, and the pre-installed IDE is Visual Studio Code.
+* The OCF does not currently provide a true replacement for Adobe Acrobat; PDFs can be opened with the Document Viewer and edited using other applications.
+Most of these applications can be found on the desktop, and all applications can be accessed from the menu in the top-left corner of the screen, analogous to the Start menu in Windows.
+
+## Persistent File Storage
+
+When you log out of one of our desktop computers, any files you saved to that computer will be erased. This is because most files saved to these computers are immediately printed, so there is no need to take up disk space holding onto them. However, some users may wish to have access to their files every time they log in to an OCF desktop. As part of your OCF account, you gain access to 5 GB of free file storage on OCF servers. This file storage is accessible by clicking on the "OCF File Storage" icon on any desktop computer or by SSHing into our account server (tsunami.ocf.berkeley.edu, and if you don't know what SSH means, read [our guide to the shell](LINK-GOES-HERE)).
+
+Files placed in the "OCF File Storage" folder are accessible from any desktop computer and are saved even after you log out, whereas files placed in the "Home" folder are local to that computer and are deleted upon log-out. The "OCF File Storage" folder should contain a folder called "public_html", which is used for web hosting – see below.
+
+## Free Printing
+
+Of course, printing is central to many users' experiences with the OCF. By signing up for an account, you get 200 free sides of printing (200 pages single-sided, 100 pages double-sided). We print black-and-white only, in economode (meaning the ink may be a bit lighter than expected). Users are limited to 20 sides of printing per day. We ask that users download or export any documents they wish to print as PDFs first, as these work best with our print server.
+
+## Web Hosting
+
+When you create an OCF account, you also create a subdomain on our website: ocf.berkeley.edu/\~yourusername. You can create your own website using HTML/CSS/JS or use a system like WordPress or Django. Alternatively, you can use your website as file storage. Either way, your website is sourced directly from the aforementioned "public_html" folder – meaning this is the folder in which you should place all content for your website. More technical information can be found at [our web hosting page](https://www.ocf.berkeley.edu/docs/services/web/).
+
+If you are a signatory of a student group and would like to request a \*.berkeley.edu website, you will need to create a group account and complete a few steps before making your request. Instructions can be found on [our vhost page](https://www.ocf.berkeley.edu/docs/services/vhost/).
+
+## Miscellaneous
+
+Various other services are also provided by the OCF to all users, such as access to our high-performance computing cluster, a personal MySQL database, access to our software mirrors, and more. For a full list and futher (more technical) documentation, visit [our services page](https://www.ocf.berkeley.edu/docs/services/).
+
+### Account Conduct
+Bear in mind that access to the OCF's services, including free printing, are conditional on your conduct. Failure to comply with account conduct policies may lead to your account being disabled. For more information, visit [our conduct page](https://www.ocf.berkeley.edu/docs/services/account/account-policies/).


### PR DESCRIPTION
This is part of my Opstaff project, but the idea is to have a simple overview of the services available to users which eschews some of the more technical documentation that most people don't understand. Ideally this doc would be used to build a new page in the account section of the website with a url like "https://www.ocf.berkeley.edu/docs/services/account/account-info" that we could then shortlink on a poster with something like "ocf.io/your-account". 