### PR TITLE
Convert as many HTTP links to HTTPS as possible

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -41,7 +41,7 @@ Also available at: https://www.apache.org/licenses/LICENSE-2.0
 
                               Apache License
                         Version 2.0, January 2004
-                     http://www.apache.org/licenses/
+                     https://www.apache.org/licenses/
 
 TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -226,7 +226,7 @@ Also available at: https://www.gnu.org/licenses/gpl-3.0.en.html
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ You can run individual tests with `venv/bin/pytest -k <test_name>` or
 
 ### Running pre-commit
 
-We use [pre-commit](http://pre-commit.com/) to lint our code before commiting.
+We use [pre-commit](https://pre-commit.com/) to lint our code before commiting.
 While some of the rules might seem a little arbitrary, it helps keep the style
 consistent, and ensure annoying things like trailing whitespace don't creep in.
 

--- a/ocfweb/announcements/templates/announcements/2016-02-09-printing.html
+++ b/ocfweb/announcements/templates/announcements/2016-02-09-printing.html
@@ -79,7 +79,7 @@
             <p>
                 Not only are we facing budget troubles, but our printers are
                 starting to fail. They've both now printed
-                <a href="http://stats.ocf.berkeley.edu/printing/historacle/">over a million pages</a>.
+                <a href="{% url 'pages_printed' %}">over a million pages</a>.
                 They're several years old and starting to show it. The
                 near-doubling of printing this semester has greatly increased
                 the frequency of paper jams and other technical glitches (just

--- a/ocfweb/component/markdown.py
+++ b/ocfweb/component/markdown.py
@@ -83,7 +83,7 @@ class BackslashLineBreakLexerMixin(_Base):
 
 class CodeRendererMixin(_Base):
     """Render highlighted code."""
-    # TODO: don't use inline styles; see http://pygments.org/docs/formatters/
+    # TODO: don't use inline styles; see https://pygments.org/docs/formatters.html
     html_formatter = HtmlFormatter(noclasses=True)
 
     def block_code(self, code: str, lang: str) -> str:

--- a/ocfweb/docs/docs/about.md
+++ b/ocfweb/docs/docs/about.md
@@ -61,8 +61,8 @@ The Open Computing Facility is a student group acting independently of the
 University of California.  We take full responsibility for our organization and
 this website.
 
-[asuc]: http://asuc.org
-[berkeley]: http://berkeley.edu
+[asuc]: https://asuc.org
+[berkeley]: https://www.berkeley.edu
 [decal]: https://decal.ocf.berkeley.edu
-[csua]: http://csua.berkeley.edu
+[csua]: https://www.csua.berkeley.edu
 [minutes]: https://www.ocf.berkeley.edu/~staff/bod/

--- a/ocfweb/docs/docs/about/formerstaff.md
+++ b/ocfweb/docs/docs/about/formerstaff.md
@@ -16,94 +16,95 @@ Some of the places OCF staffers have gone on to work at:
 * Berkeley Multimedia Research Center
 * Center for Extreme Ultraviolet Astrophysics
 * EECS Department Technical & Computing Services (TCS)
-* [Campus Information Systems & Technology (IS&T)](http://ist.berkeley.edu/)
-* [Haas School of Business](http://www.haas.berkeley.edu/)
+* [Campus Information Systems & Technology (IS&T)](https://technology.berkeley.edu/)
+* [Haas School of Business](https://haas.berkeley.edu/)
 * InfoPad Research Group, Electrical Engineering
-* [Lawrence Berkeley National Lab](http://www.lbl.gov/)
-* [Letters & Science Computer Resources](http://ls.berkeley.edu/lscr/)
+* [Lawrence Berkeley National Lab](https://www.lbl.gov/)
+* [Letters & Science Computer Resources](https://ls.berkeley.edu/)
 * [Molecular & Cell Biology](https://mcb.berkeley.edu)
-* [Residential Computing Services, Housing and Dining](http://www.rescomp.berkeley.edu)
-* [School of Information Management and Systems](http://www.sims.berkeley.edu/)
-* [School of Law - Boalt Hall](http://www.law.berkeley.edu/)
+* Residential Computing Services, Housing and Dining (now called [Student
+  Technology Services](https://studenttech.berkeley.edu/home))
+* [School of Information Management and Systems](https://www.ischool.berkeley.edu/)
+* [School of Law - Boalt Hall](https://www.law.berkeley.edu/)
 * [Statistical Computing Facility](http://statistics.berkeley.edu/computing)
 
 ### Elsewhere
 
-* [Adobe](http://www.adobe.com)
-* [The Aerospace Corporation](http://www.aerospace.org)
-* [Amazon](http://www.amazon.com)
-* [Americorps](http://www.nationalservice.gov/programs/americorps)
+* [Adobe](https://www.adobe.com)
+* [The Aerospace Corporation](https://www.aerospace.org)
+* [Amazon](https://www.amazon.com)
+* [Americorps](https://www.nationalservice.gov/programs/americorps)
 * [Anderson Consulting](http://www.andersonconsultinggroup.com)
-* [Apple](http://www.apple.com/)
+* [Apple](https://www.apple.com/)
 * [Applemon](https://applemon.com/)
 * [Arista](https://www.arista.com/en/)
-* [Arthur Andersen & Co.](http://www.arthurandersen.com/) (Information Services Group)
-* [Bank of America](http://www.bofa.com/)
+* Arthur Andersen & Co. (Information Services Group)
+* [Bank of America](https://www.bankofamerica.com/)
 * Bay Area BioFuel
 * Berkeley Systems
 * BigBook
-* [BuzzFeed](http://www.buzzfeed.com)
-* [Carnegie Mellon University School of Computer Science](http://www.cs.cmu.edu/)
-* [Cisco Systems, Inc.](http://www.cisco.com/)
-* [Code for America](http://www.codeforamerica.org)
-* [Compaq](http://www.compaq.com/)
-* [CRL Network Services](http://www.crl.com/)
-* Digital Equipment Corporation (acquired by [Compaq](http://www.compaq.com/))
+* [BuzzFeed](https://www.buzzfeed.com/)
+* [Carnegie Mellon University School of Computer Science](https://www.cs.cmu.edu/)
+* [Cisco Systems, Inc.](https://www.cisco.com/)
+* [Code for America](https://www.codeforamerica.org/)
+* Compaq
+* CRL Network Services
+* Digital Equipment Corporation (acquired by Compaq)
 * [Drogin, Kakigi, & Assoc.](http://www.dkstat.com/)
 * [Eventbrite](https://www.eventbrite.com)
 * [Facebook](https://www.facebook.com)
-* [Forte Software](http://www.forte.com/) (now part of [Sun Microsystems](http://www.sun.com/))
-* Framed Data (acquired by [Square](http://www.squareup.com))
-* [Fry's Electronics](http://www.outpost.com/)
+* Forte Software (now part of [Sun Microsystems](https://www.oracle.com/sun/))
+* Framed Data (acquired by [Square](https://squareup.com/us/en))
+* [Fry's Electronics](https://www.frys.com/)
 * Global Network Navigator, Inc.
-* [Goldman Sachs](http://www.goldmansachs.com/)
+* [Goldman Sachs](https://www.goldmansachs.com/)
 * [Google](https://www.google.com)
-* [HotWired](http://www.hotwired.com/)
-* [Howard Hughes Medical Institute](http://www.hhmi.org/)
-* [IBM](http://www.ibm.com/)
+* HotWired
+* [Howard Hughes Medical Institute](https://www.hhmi.org/)
+* [IBM](https://www.ibm.com/us-en/)
 * [Infer](https://www.infer.com)
 * Inktomi (acquired by [Yahoo!](https://www.yahoo.com))
 * Interactive Development Environments
-* [Legato](http://www.legato.com/)
+* Legato
 * [LinkedIn](https://www.linkedin.com)
 * [Lookout Mobile Security](https://www.lookout.com)
-* [Massachusetts Institute of Technology](http://web.mit.edu)
-* [Microsoft](http://www.microsoft.com/)
-* [Mindsource Software Engineers](http://www.mindsrc.com/)
-* [Netcom](http://www.netcom.com/)
+* [Massachusetts Institute of Technology](https://web.mit.edu/)
+* [Microsoft](https://www.microsoft.com/en-us/)
+* Mindsource Software Engineers
+* Netcom
 * MetaReward/NetFlip
-* [MixPanel](http://www.mixpanel.com)
-* [Mozilla Corp](http://www.mozilla.org)
-* [Netblue](http://www.netblue.com/)
-* [Netscape](http://www.netscape.com/)
-* [Network Appliance](http://www.netapp.com/)
-* [Neuron Data](http://www.neurondata.com/)
+* [MixPanel](https://mixpanel.com)
+* [Mozilla](https://www.mozilla.org/en-US/)
+* Netblue
+* Netscape
+* [Network Appliance](https://www.netapp.com/us/index.aspx)
+* Neuron Data
 * Newspager Corp. of America
 * [New York State Office of the Attorney General](https://ag.ny.gov)
 * [Okta](https://www.okta.com)
-* [Oracle](http://www.oracle.com/)
+* [Oracle](https://www.oracle.com/index.html)
 * [Palantir](https://www.palantir.com)
 * [Patreon](https://www.patreon.com/)
-* [Rackspace](http://www.rackspace.com)
-* [7M Consulting](http://www.7mconsulting.com)
-* [SiByte, Inc](http://sibyte.broadcom.com) (acquired by [Broadcom](http://www.broadcom.com))
-* [Silicon Graphics (SGI)](http://www.sgi.com/)
-* [Snapfish](http://www.snapfish.com/)
-* [Splunk](http://www.splunk.com/)
-* [Square](http://www.squareup.com)
-* [StarNine Technologies](http://www.starnine.com/)
-* [Sun Microsystems](http://www.sun.com/)
-* [Taos Mountain Software](http://www.taos.com)
-* [TCSI Corp.](http://www.tcs.com/)
+* [Rackspace](https://www.rackspace.com/)
+* 7M Consulting
+* SiByte, Inc (acquired by [Broadcom](https://www.broadcom.com/))
+* Silicon Graphics (SGI)
+* [Snapfish](https://www.snapfish.com/home)
+* [Splunk](https://www.splunk.com/)
+* [Square](https://squareup.com/us/en)
+* StarNine Technologies
+* Sun Microsystems (acquired by [Oracle](https://www.oracle.com/sun/))
+* [Taos Mountain Software](https://www.taos.com/)
+* [TCSI Corp.](https://www.tcs.com/)
 * [Twitter](https://twitter.com)
 * [Uber](https://www.uber.com)
-* [Walmart.com](http://www.walmart.com/)
-* [Wells Fargo Bank](http://www.wellsfargo.com/)
+* [Walmart.com](https://www.walmart.com/)
+* [Wells Fargo Bank](https://www.wellsfargo.com/)
 * [The White House](https://www.whitehouse.gov)
-* [Yahoo!](http://www.yahoo.com)
+* [Yahoo!](https://www.yahoo.com/)
 * [Yelp](https://www.yelp.com/)
-* [Yggdrasil Computing, Inc.](http://www.yggdrasil.com/)
-* Z-Code Software (acquired by [Microfocus](http://www.microfocus.com))
+* Yggdrasil Computing, Inc.
+* Z-Code Software (acquired by [Microfocus](https://www.microfocus.com/en-us/home))
 
 (Many of the above are places people have taken full-time jobs at. Some
 however, were co-ops or assignments done as a contractor for an agency such as
@@ -118,14 +119,14 @@ gained as OCF staff:
 
 * ASUConline
 * [CalLUG - the UCB Linux User's Group](https://www.ocf.berkeley.edu/~linux/)
-* [Computer Science Undergrad Assoc.](http://www.csua.berkeley.edu/)
-* [Eta Kappa Nu](http://www-hkn.eecs.berkeley.edu/) (EECS Honor Society)
+* [Computer Science Undergrad Assoc.](https://www.csua.berkeley.edu/)
+* [Eta Kappa Nu](https://hkn.eecs.berkeley.edu/) (EECS Honor Society)
 * [Experimental Computing Facility](https://callink.berkeley.edu/organization/xcf)
 * Students Improving Campus Online Services
 * [U. C. Society of Electrical Engineers](https://ieee.berkeley.edu) (IEEE Student Chapter)
-* [Upsilon Pi Epsilon](http://upe.berkeley.edu/) (CS Honor Society)
+* [Upsilon Pi Epsilon](https://upe.berkeley.edu/) (CS Honor Society)
 
 ### Elsewhere
 
-* [The NetBSD Project](http://www.netbsd.org/)
+* [The NetBSD Project](https://www.netbsd.org/)
 * [NetDay '96](https://en.wikipedia.org/wiki/NetDay#NetDay_.2796)

--- a/ocfweb/docs/docs/contact/irc.md
+++ b/ocfweb/docs/docs/contact/irc.md
@@ -126,4 +126,4 @@ authenticate with NickServ if you get disconnected from ZNC.
 [webirc]: https://irc.ocf.berkeley.edu
 [thelounge]: https://thelounge.github.io
 [hexchat]: https://hexchat.github.io
-[nickserv]: http://wiki.znc.in/Nickserv
+[nickserv]: https://wiki.znc.in/Nickserv

--- a/ocfweb/docs/docs/services/hpc.md
+++ b/ocfweb/docs/docs/services/hpc.md
@@ -178,6 +178,6 @@ able to interface with the GPUs.
 [mac_install]: https://singularity.lbl.gov/install-mac
 [win_install]: https://singularity.lbl.gov/install-windows
 [linux_install]: https://singularity.lbl.gov/install-linux
-[brc_slurm]: http://research-it.berkeley.edu/services/high-performance-computing/running-your-jobs
+[brc_slurm]: https://research-it.berkeley.edu/services/high-performance-computing/running-your-jobs
 [corruption-cpu]: https://ark.intel.com/products/92984/Intel-Xeon-Processor-E5-2640-v4-25M-Cache-2-40-GHz-
 [stf]: https://techfund.berkeley.edu

--- a/ocfweb/docs/docs/services/shell.md
+++ b/ocfweb/docs/docs/services/shell.md
@@ -44,7 +44,7 @@ On Windows, use [PuTTY][putty] (download the `putty.exe` file):
 * Host Name: `ssh.ocf.berkeley.edu`
 * Port: 22
 
-[putty]: http://www.chiark.greenend.org.uk/~sgtatham/putty/download.html
+[putty]: https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html
 
 #### Mosh
 
@@ -62,7 +62,7 @@ you can use the command line utility `sftp`, or a graphical program such as
 
 [sftp]: https://en.wikipedia.org/wiki/SSH_File_Transfer_Protocol
 [filezilla]: https://filezilla-project.org/
-[winscp]: http://winscp.net/
+[winscp]: https://winscp.net/eng/index.php
 [cyberduck]: https://cyberduck.io/
 
 Otherwise, use the following information in your SFTP client.

--- a/ocfweb/docs/docs/services/vhost.md
+++ b/ocfweb/docs/docs/services/vhost.md
@@ -126,7 +126,7 @@ groups.
 
 [computer-use]: https://security.berkeley.edu/policy/usepolicy.html
 [dns-policy]: https://security.berkeley.edu/policy/dns
-[rso-domains]: http://lead.berkeley.edu/wp-content/uploads/2014/12/student-org-domain-guidelines.pdf
+[rso-domains]: https://lead.berkeley.edu/wp-content/uploads/2014/12/student-org-domain-guidelines.pdf
 
 In particular,
 

--- a/ocfweb/docs/docs/services/web/flask.md
+++ b/ocfweb/docs/docs/services/web/flask.md
@@ -4,9 +4,9 @@
 If you are using a group account, you may wish to consider
 [[apphosting|doc services/webapps]] instead.**
 
-[Flask](http://flask.pocoo.org/) is a popular microframework for Python web
-development. Using it on the OCF servers requires only just a little extra
-configuration.
+[Flask](https://palletsprojects.com/p/flask/) is a popular microframework for
+Python web development. Using it on the OCF servers requires only just a little
+extra configuration.
 
 
 ## Setting up a Flask project

--- a/ocfweb/docs/docs/services/web/php.md
+++ b/ocfweb/docs/docs/services/web/php.md
@@ -3,19 +3,19 @@
 `death`, the OCF webserver, currently runs PHP 7.0 with the following
 non-standard packages installed:
 
-* [APCu](http://php.net/manual/en/book.apcu.php) (opcode caching)
-* [BC Math](http://php.net/manual/en/book.bc.php) (arbitrary precision math)
-* [Bzip2](http://php.net/manual/en/book.bzip2.php) (compression library)
-* [cURL](http://php.net/manual/en/book.curl.php) (networking library)
-* [DBA](http://php.net/manual/en/book.dba.php) (database connector)
-* [GD](http://php.net/manual/en/book.image.php) (graphics library)
-* [MB String](http://php.net/manual/en/book.mbstring.php) (string encoding)
-* [Mcrypt](http://php.net/manual/en/book.mcrypt.php) (cryptography library)
-* [MySQL](http://php.net/manual/en/book.mysqli.php) (database connector)
-* [SQLite](http://php.net/manual/en/book.sqlite.php) (database connector)
-* [SOAP](http://php.net/manual/en/book.soap.php) (messaging protocol library)
-* [XML](http://php.net/manual/en/book.xml.php) (markup parsing library)
-* [ZIP](http://php.net/manual/en/book.zip.php) (compression library)
+* [APCu](https://www.php.net/manual/en/book.apcu.php) (opcode caching)
+* [BC Math](https://www.php.net/manual/en/book.bc.php) (arbitrary precision math)
+* [Bzip2](https://www.php.net/manual/en/book.bzip2.php) (compression library)
+* [cURL](https://www.php.net/manual/en/book.curl.php) (networking library)
+* [DBA](https://www.php.net/manual/en/book.dba.php) (database connector)
+* [GD](https://www.php.net/manual/en/book.image.php) (graphics library)
+* [MB String](https://www.php.net/manual/en/book.mbstring.php) (string encoding)
+* [Mcrypt](https://www.php.net/manual/en/book.mcrypt.php) (cryptography library)
+* [MySQL](https://www.php.net/manual/en/book.mysqli.php) (database connector)
+* [SQLite](https://www.php.net/manual/en/book.sqlite.php) (database connector)
+* [SOAP](https://www.php.net/manual/en/book.soap.php) (messaging protocol library)
+* [XML](https://www.php.net/manual/en/book.xml.php) (markup parsing library)
+* [ZIP](https://www.php.net/manual/en/book.zip.php) (compression library)
 
 For a full list of available modules, run `phpinfo()` from a PHP script.
 Plase [[contact us|doc contact]] if you are missing a module that you need

--- a/ocfweb/docs/docs/services/web/wordpress.md
+++ b/ocfweb/docs/docs/services/web/wordpress.md
@@ -32,7 +32,7 @@ simple instructions:
    ```
 
    This will download the latest version of WordPress into your web directory
-   using [wp-cli](http://wp-cli.org/).
+   using [wp-cli](https://wp-cli.org/).
 
 5. Visit your web admin dashboard and complete the installation process. Your
    website will be `https://www.ocf.berkeley.edu/~username` and the dashboard
@@ -187,4 +187,4 @@ you may additionally need to edit the `.htaccess` file in the root of your
 WordPress installation. Specifically, you should replace `/~yourgroup/` with
 `/` whenever it occurs in that file.
 
-[wp-cli]: http://wp-cli.org/
+[wp-cli]: https://wp-cli.org/

--- a/ocfweb/docs/docs/staff/backend/firewall.md
+++ b/ocfweb/docs/docs/staff/backend/firewall.md
@@ -22,7 +22,7 @@ set up the SOCKS proxy (through your OS or through your browser's settings) to
 use the proxy on `localhost` and port `8000`.
 
 [panorama]: https://panorama.net.berkeley.edu
-[library-vpn]: http://www.lib.berkeley.edu/using-the-libraries/vpn
+[library-vpn]: https://www.lib.berkeley.edu/using-the-libraries/vpn
 
 To sign in to administer the firewall, make sure to use the single sign-on
 (SSO) option, and it will ask for CalNet authentication.

--- a/ocfweb/docs/docs/staff/backend/kerberos.md
+++ b/ocfweb/docs/docs/staff/backend/kerberos.md
@@ -215,5 +215,5 @@ or a HTTP Kerberos login, then they make more requests to the KDC:
    will verify the ticket with the KDC when used, to make sure it is valid for
    the user issuing the request.
 
-[eli5]: http://www.roguelynn.com/words/explain-like-im-5-kerberos/
+[eli5]: https://www.roguelynn.com/words/explain-like-im-5-kerberos/
 [kdc]: https://github.com/ocf/puppet/blob/17bc94b395e254529d97c84fb044f76931439fd7/modules/ocf_kerberos/files/kdc.conf#L13

--- a/ocfweb/docs/docs/staff/backend/mail.md
+++ b/ocfweb/docs/docs/staff/backend/mail.md
@@ -47,5 +47,5 @@ We are whitelisted by
 
 We are also registered with
 
- - [abuse.net](http://abuse.net/lookup.phtml?domain=ocf.berkeley.edu)
+ - [abuse.net](https://www.abuse.net/lookup.phtml?domain=ocf.berkeley.edu)
  - SpamCop (ISP account set to receive summary reports)

--- a/ocfweb/docs/docs/staff/procedures/accounts/association.md
+++ b/ocfweb/docs/docs/staff/procedures/accounts/association.md
@@ -24,7 +24,7 @@ Open the LDAP record for editing.
     $ kinit <staffusername>/admin ldapvi uid=<username>
 
 After looking up the user's UID in the [University
-directory](http://www.berkeley.edu/directory), add it to the record with a line
+directory](https://www.berkeley.edu/directory), add it to the record with a line
 like this:
 
     calnetUid: 6081

--- a/ocfweb/docs/docs/staff/procedures/backporting-packages.md
+++ b/ocfweb/docs/docs/staff/procedures/backporting-packages.md
@@ -2,7 +2,7 @@
 
 It seems like we often either need a newer version of a package, or to apply
 our own patch to some package. We have [an apt
-repo](http://apt.ocf.berkeley.edu/) to which we upload these packages.
+repo](https://apt.ocf.berkeley.edu/) to which we upload these packages.
 
 There is a useful Debian wiki page
 [SimpleBackportCreation](https://wiki.debian.org/SimpleBackportCreation) but

--- a/ocfweb/docs/docs/staff/procedures/dmca.md
+++ b/ocfweb/docs/docs/staff/procedures/dmca.md
@@ -15,7 +15,7 @@ An example of instructions for a DMCA takedown notice is the
 If a DMCA takedown notice is received, refer to
 [Guidelines for Compliance with the Online Service Provider Provisions
 of the Digital Millennium Copyright
-Act](http://policy.ucop.edu/doc/7000472/DMCA), a 6-page document by the
+Act](https://policy.ucop.edu/doc/7000472/DMCA), a 6-page document by the
 University, which describes the procedure that we should follow:
 
  > 1. "Notice" is sent to the service provider by the complaining party.

--- a/ocfweb/docs/docs/staff/procedures/editing-docs.md
+++ b/ocfweb/docs/docs/staff/procedures/editing-docs.md
@@ -45,5 +45,5 @@ on working with OCF repos.
 [markdown]: https://daringfireball.net/projects/markdown/syntax
 [ocfweb]: https://github.com/ocf/ocfweb
 [mistune]: https://github.com/lepture/mistune
-[pygments]: http://pygments.org/
+[pygments]: https://pygments.org/
 [jenkins]: https://jenkins.ocf.berkeley.edu

--- a/ocfweb/docs/docs/staff/procedures/printing.md
+++ b/ocfweb/docs/docs/staff/procedures/printing.md
@@ -95,8 +95,8 @@ The following is a list of our printers and their IDs, from left to right:
    pages printed over time)
 
 
-[toner]: http://www.staples.com/HP-64X-Black-Toner-Cartridge-CC364XD-High-Yield-Twin-Pack/product_821762
-[pmp]: http://campuslifeservices.ucsf.edu/documentsmedia/services/print_management
+[toner]: https://www.staples.com/HP-64X-Black-Toner-Cartridge-CC364XD-High-Yield-Twin-Pack/product_821762
+[pmp]: https://campuslifeservices.ucsf.edu/documentsmedia/services/print_management
 [printer-dashboard]: https://ocf.io/printers
 [printer-summary]: https://www.ocf.berkeley.edu/stats/
 [pages-printed]: https://www.ocf.berkeley.edu/stats/printing/pages-printed

--- a/ocfweb/docs/docs/staff/procedures/vhost.md
+++ b/ocfweb/docs/docs/staff/procedures/vhost.md
@@ -9,7 +9,7 @@
   undue effort and links to the OCF home page
 * Request is made by a registered and active student organization in CalLink
   (LEAD Center), request is sponsored by an [administrative
-  official](http://compliance.berkeley.edu/delegation/principles), or request
+  official](https://compliance.berkeley.edu/delegation/principles), or request
   is for the account of a faculty or staff member
 * For RSOs, request is made by a signatory of the group in question (use
   `signat group <group>` to see signatories)
@@ -17,7 +17,7 @@
   their department
 * Account does not already have a virtual host, or has an exception from a Site
   Manager
-* For RSOs, domain name complies with [LEAD Center guidelines](http://lead.berkeley.edu/wp-content/uploads/2014/12/student-org-domain-guidelines.pdf). In
+* For RSOs, domain name complies with [LEAD Center guidelines](https://lead.berkeley.edu/wp-content/uploads/2014/12/student-org-domain-guidelines.pdf). In
   particular, requested domain name is sufficiently similar to their official
   name and wouldn't potentially be confused with a university department.
 * For non-berkeley.edu domains, domain name has been approved by a (D)GM or
@@ -38,7 +38,7 @@ about an additional hour to take effect (for the first hour, it will be
 HTTP-only).
 
 Next, request the following DNS records from the [University
-hostmaster](http://www.net.berkeley.edu/hostmaster/):
+hostmaster][campus-hostmistress]:
 
     hostname.Berkeley.EDU. IN A 169.229.226.23
     hostname.Berkeley.EDU. IN AAAA 2607:f140:8801::1:23
@@ -110,8 +110,7 @@ Once the cronjob completes, the application will be available at:
 `VHOST_NAME` is the configured name from above.
 
 Once the website is developed and meets policy checklist, request the following
-DNS record from the [University
-hostmaster](http://www.net.berkeley.edu/hostmaster/):
+DNS record from the [University hostmaster][campus-hostmistress]:
 
     hostname.Berkeley.EDU. IN A 169.229.226.49
     hostname.Berkeley.EDU. IN AAAA 2607:f140:8801::1:49
@@ -121,3 +120,5 @@ Remember to request that any existing records be dropped as well. You can check
 for records with `dig hostname.berkeley.edu [A|AAAA|MX]`. The nginx running on
 apphosting server will return a `502 Bad Gateway` or actual content if the
 apphost is configured properly, and a `403 Forbidden` otherwise.
+
+[campus-hostmistress]: https://ucb.service-now.com/kb_view.do?sysparm_article=KBT0012470

--- a/ocfweb/docs/docs/staff/rebuild/rt.md
+++ b/ocfweb/docs/docs/staff/rebuild/rt.md
@@ -316,7 +316,7 @@ Both Apache 2 and Nginx installation are listed below. Pick your poison...
        sudo service rt4-fcgi restart
 
 9. Install the RT [mailgate
-   program](http://requesttracker.wikia.com/wiki/EmailInterface#RT.27s_mail_gate)
+   program](https://rt-wiki.bestpractical.com/wiki/EmailInterface#RT.27s_mail_gate)
    on the mail server.
 
    squeeze-backports is required here too.
@@ -369,7 +369,7 @@ Both Apache 2 and Nginx installation are listed below. Pick your poison...
    be artificially limited in rights elsewhere on RT for your own protection:
    ["Starting from version 3.2 (or 3.4?) RT doesn't show users with the
    SuperUser right in a ticket owner
-   select-box."](http://requesttracker.wikia.com/wiki/SuperUser)
+   select-box."](https://rt-wiki.bestpractical.com/wiki/SuperUser)
 
    Re-enable Kerberos password authentication in Apache configuration and
    force-reload Apache.
@@ -387,7 +387,7 @@ Both Apache 2 and Nginx installation are listed below. Pick your poison...
    In this configuration I see the set of RT privileged users to be the same as
    the set of users in group "Staff". This may change.
 
-2. Enable user rights. [This](http://requesttracker.wikia.com/wiki/Rights)
+2. Enable user rights. [This](https://rt-wiki.bestpractical.com/wiki/Rights)
    guide is being followed.
 
    Go to Tools > Configuration > Global > Group Rights.
@@ -484,8 +484,8 @@ Both Apache 2 and Nginx installation are listed below. Pick your poison...
 
    References:
    [1](http://lists.bestpractical.com/pipermail/rt-users/2005-February/028837.html)
-   [2](http://requesttracker.wikia.com/wiki/UntouchedInHours)
-   [3](http://requesttracker.wikia.com/wiki/TimedNotifications)
+   [2](https://rt-wiki.bestpractical.com/wiki/UntouchedInHours)
+   [3](https://rt-wiki.bestpractical.com/wiki/TimedNotifications)
 
 ## Notes
 
@@ -498,12 +498,12 @@ Both Apache 2 and Nginx installation are listed below. Pick your poison...
 * Fix Chrome double login, if possible.
   * Doesn't occur when running Nginx, only Apache 2.
 * Set up ticket autoclose using
-  http://requesttracker.wikia.com/wiki/UntouchedInHours or
-  http://requesttracker.wikia.com/wiki/TimedNotifications
+  https://rt-wiki.bestpractical.com/wiki/UntouchedInHours or
+  https://rt-wiki.bestpractical.com/wiki/TimedNotifications
 
 ## References
 
-* http://requesttracker.wikia.com/wiki/HomePage
+* https://rt-wiki.bestpractical.com/wiki/Main_Page
 
 [rt-puppet]: https://github.com/ocf/puppet/tree/fc6d4242ba773cefbc9e7c1ea542f8f7de3e8785/modules/ocf_rt
 [rt-docker]: https://github.com/ocf/rt

--- a/ocfweb/docs/templates/docs/lab.html
+++ b/ocfweb/docs/templates/docs/lab.html
@@ -23,7 +23,7 @@
                 <p>
                     OCF computers include free and open-source software such as
                     <a href="https://www.libreoffice.org/">LibreOffice</a> (similar to
-                    Microsoft Office), <a href="http://www.gimp.org/">GIMP</a> (similar
+                    Microsoft Office), <a href="https://www.gimp.org/">GIMP</a> (similar
                     to Adobe Photoshop), and more.
                 </p>
 

--- a/ocfweb/templates/partials/open-source-pics.html
+++ b/ocfweb/templates/partials/open-source-pics.html
@@ -7,6 +7,6 @@
     <a href="https://www.apache.org/"><img src="{% static 'img/about/logos/apache.png' %}" alt="apache" title="Apache" /></a>
     <a href="https://www.mariadb.org/"><img src="{% static 'img/about/logos/mariadb.png' %}" alt="mariadb" title="MariaDB" /></a>
     <a href="https://www.xfce.org/"><img src="{% static 'img/about/logos/xfce.png' %}" alt="xfce" title="Xfce" /></a>
-    <a href="http://www.vim.org/"><img src="{% static 'img/about/logos/vim.png' %}" alt="vim" title="vim" /></a>
+    <a href="https://www.vim.org/"><img src="{% static 'img/about/logos/vim.png' %}" alt="vim" title="vim" /></a>
     <a href="https://www.gnu.org/software/emacs/"><img src="{% static 'img/about/logos/emacs.png' %}" alt="emacs" title="Emacs" /></a>
 </p>


### PR DESCRIPTION
This branch is pretty much just me looking at all the `http:` links and seeing if they can be turned into `https:` links.

When I found a dead link I tried to replace it with a working link; if I couldn't find one (particularly on the "where did alumni go" page), I removed the link rather than have a broken link or a link pointing to a domain parking page. (My thinking is that these domains are probably no longer owned by the original organization and could point anywhere in the future.)

There are about 10 remaining actual HTTP links that I wasn't able to update (not counting things like XML schema references, vendored code, intentional uses of an HTTP link, etc.).