### PR TITLE
update officers page and add committee heads

### DIFF
--- a/ocfweb/docs/templates/docs/officers.html
+++ b/ocfweb/docs/templates/docs/officers.html
@@ -33,7 +33,7 @@
             {% endif %}
           {% endfor %}
         </p>
-        {% if current_term.dgms|length > 0 %}
+        {% if current_term.dgms %}
           <h4>
             Deputy General Managers
           </h4>
@@ -62,7 +62,7 @@
             {% endif %}
           {% endfor %}
         </p>
-        {% if current_term.dsms|length > 0 %}
+        {% if current_term.dsms %}
           <h4>
             Deputy Site Managers
           </h4>
@@ -80,7 +80,7 @@
           the OCF lab and other services. They are elected by the Board of
           Directors at the end of each semester.
         </p>
-      {% if current_term.heads|length > 0 %}
+      {% if current_term.heads %}
         <h3>
           Committee Heads
         </h3>

--- a/ocfweb/docs/templates/docs/officers.html
+++ b/ocfweb/docs/templates/docs/officers.html
@@ -80,6 +80,26 @@
           the OCF lab and other services. They are elected by the Board of
           Directors at the end of each semester.
         </p>
+      {% if current_term.heads|length > 0 %}
+        <h3>
+          Committee Heads
+        </h3>
+          {% for committee in current_term.heads %}
+            <h4>{{ committee.name }} Committee Heads</h4>
+              <p>
+                {% for head in committee.heads %}
+                  {% if head.end is None %}
+                    <strong>{{ head.name }}</strong> &lt;{{ head.uid }}&gt;
+                    {% if head.acting %} (acting) {% endif %}<br>
+                  {% endif %}
+                {% endfor %}
+              </p>
+          {% endfor %}
+          <p>
+            Committee heads guide the work of the various committees that
+            function within the OCF.
+          </p>
+      {% endif %}
     <h2>Previous officers</h2>
     <p>
       Terms began and ended during the ninth week of the semester until Fall

--- a/ocfweb/docs/views/officers.py
+++ b/ocfweb/docs/views/officers.py
@@ -15,7 +15,8 @@ from ocflib.account.search import user_attrs
 
 from ocfweb import caching
 
-_Term = namedtuple('_Term', ['name', 'gms', 'sms', 'dgms', 'dsms'])
+_Term = namedtuple('_Term', ['name', 'gms', 'sms', 'dgms', 'dsms', 'heads'])
+Committee = namedtuple('Committee', ['name', 'heads'])
 
 
 def Term(
@@ -24,12 +25,17 @@ def Term(
     sms: List[Any],
     dgms: Optional[List[Any]] = None,
     dsms: Optional[List[Any]] = None,
+    heads: Optional[List[Tuple[str, List[Any]]]] = None,
 ) -> _Term:
     gms = list(map(Officer.from_uid_or_info, gms))
     sms = list(map(Officer.from_uid_or_info, sms))
     dgms = list(map(Officer.from_uid_or_info, dgms or []))
     dsms = list(map(Officer.from_uid_or_info, dsms or []))
-    return _Term(name, gms, sms, dgms, dsms)
+    heads = [
+        Committee(committee[0], list(map(Officer.from_uid_or_info, committee[1])))
+        for committee in heads or []
+    ]
+    return _Term(name, gms, sms, dgms, dsms, heads)
 
 
 class Officer(namedtuple('Officer', ['uid', 'name', 'start', 'end', 'acting'])):
@@ -237,7 +243,25 @@ def _bod_terms() -> List[Any]:
             dgms=['asai'], dsms=['ethanhs', 'cooperc'],
         ),
         Term(
-            'Fall 2019', gms=['cooperc', 'php'], sms=['ethanhs', 'fydai'],
+            'Fall 2019',
+            gms=['cooperc', 'php'],
+            sms=[
+                ('ethanhs', date(2019, 5, 18), date(2019, 11, 18)),
+                'fydai',
+            ],
+        ),
+        Term(
+            'Spring 2020',
+            gms=['dphan', 'bernardzhao'],
+            sms=['cooperc', 'jaw'],
+            heads=[
+                ('University Affairs', ['dphan', 'bernardzhao']),
+                ('Internal', ['php', 'kmo']),
+                ('Industry and Alumni Relations', ['asai', 'rachy']),
+                ('Finance', ['ncberberi', 'nint']),
+                ('Communication', ['rachy']),
+                ('DeCal', ['exiang', 'bencuan', 'kmo']),
+            ],
         ),
     ]
 
@@ -250,6 +274,6 @@ def officers(doc: Any, request: HttpRequest) -> HttpResponse:
         {
             'title': doc.title,
             'current_term': terms[-1],
-            'previous_terms': reversed(terms[:-1]),
+            'previous_terms': terms[-2::-1],
         },
     )


### PR DESCRIPTION
This updates the officers page to include recent elections. It also adds committee heads to the officers page. I didn't add committee heads to the "previous officers" section, because I wasn't sure how to do it (and we don't have any official historical committee heads). We should think about if we want to do this and if so how.

Ideally this can be merged when the new terms take effect on December 21.