### PR TITLE
Update Callink API to use new URL

### DIFF
--- a/ocfweb/docs/docs/staff/scripts/signat.md
+++ b/ocfweb/docs/docs/staff/scripts/signat.md
@@ -16,7 +16,7 @@ up UIDs and OIDs in OCF [[LDAP|doc staff/backend/ldap]] and names in the
 university's [LDAP directory service][berkeleyldap].
 
 [ocflib]: github.com/ocf/ocflib
-[callinkapi]: https://saappiis4.sait-west.berkeley.edu/StudentGroupServiceV2/service.asmx
+[callinkapi]: https://studentgroupservice.sait-west.berkeley.edu/service.asmx
 [berkeleyldap]: https://wikihub.berkeley.edu/display/calnet/LDAP+Directory+Service
 
 ## Usage


### PR DESCRIPTION
https://github.com/ocf/ocflib/pull/199 leftovers