### PR TITLE
Sort docs by title instead of path

### DIFF
--- a/ocfweb/docs/templatetags/docs.py
+++ b/ocfweb/docs/templatetags/docs.py
@@ -52,7 +52,7 @@ def doc_tree(
                         if doc.name.startswith(root) and not exclude.match(doc.name)
                     }
                 ],
-                key=attrgetter('path'),
+                key=attrgetter('title'),
             ),
         )
 


### PR DESCRIPTION
This moves from this (which I found a bit confusing until I realized it was done by path so `vhost.md` and `xmpp.md` are near the end even though their titles would not lead to that same position):

![ocf-docs-sorting-status-quo](https://user-images.githubusercontent.com/1523594/81660182-4908c600-93ef-11ea-9b61-2401d1eff08a.png)

To something like this:

![ocf-docs-sorting-new](https://user-images.githubusercontent.com/1523594/81660196-4dcd7a00-93ef-11ea-9a67-58e1ce603f92.png)

(taken from the table of contents on https://www.ocf.berkeley.edu/docs/staff/)