### PR TITLE
Fix incorrect detection of requested vhost domain type

### DIFF
--- a/ocfweb/account/templates/account/vhost/index.html
+++ b/ocfweb/account/templates/account/vhost/index.html
@@ -56,7 +56,7 @@
                     </div>
                 {% endif %}
 
-                {{form.requested_own_domain|bootstrap}}
+                {{form.requested_domain_type|bootstrap}}
                 {{form.requested_subdomain|bootstrap}}
 
                 <p><strong>Website requirements:</strong></p>

--- a/ocfweb/account/vhost.py
+++ b/ocfweb/account/vhost.py
@@ -173,15 +173,15 @@ def request_vhost_success(request: HttpRequest) -> HttpResponse:
 
 class VirtualHostForm(Form):
     # requested subdomain
-    requested_own_domain = forms.ChoiceField(
+    requested_domain_type = forms.ChoiceField(
         choices=[
             (
-                False, 'I would like to request a berkeley.edu domain \
+                'berkeley', 'I would like to request a berkeley.edu domain \
                      (most student groups want this).',
             ),
-            (True, 'I want to use the domain I already own.'),
+            ('own', 'I want to use the domain I already own.'),
         ],
-        widget=forms.RadioSelect(),
+        widget=forms.RadioSelect,
     )
 
     requested_subdomain = forms.CharField(
@@ -273,8 +273,7 @@ class VirtualHostForm(Form):
 
     def clean_requested_subdomain(self) -> str:
         requested_subdomain = self.cleaned_data['requested_subdomain'].lower().strip()
-
-        if self.cleaned_data['requested_own_domain']:
+        if self.cleaned_data['requested_domain_type'] == 'own':
             if not valid_domain_external(requested_subdomain):
                 raise forms.ValidationError(
                     'This does not appear to be a valid domain. '


### PR DESCRIPTION
Previously we were trying to compare with a stringified boolean,
resulting in the condition being true all the time. This should be
clearer and also avoid the mess with using a BooleanField (since
browsers may not submit a BooleanField that is false.