### PR TITLE
wording fixes

### DIFF
--- a/ocfweb/docs/docs/communications/blm.md
+++ b/ocfweb/docs/docs/communications/blm.md
@@ -12,4 +12,4 @@ We welcome any suggestions on how the OCF can better help your cause, whether wi
 
 ## OCF Donation Matching
 
-The OCF will be matching donations to BLM-related causes, up to $1000. These donations will come from our miscellaneous funds, sourced primarily from OCF staff. You can participate by sending the receipt of your donation made on or after 19 June 2020 to [help@ocf.berkeley.edu](mailto:help@ocf.berkeley.edu).
+The OCF will be matching donations to BLM-related causes, up to $1000 total. These donations will come from our miscellaneous funds, sourced primarily from OCF staff. You can participate by sending the receipt of your donation made on or after 19 June 2020 to [help@ocf.berkeley.edu](mailto:help@ocf.berkeley.edu).

--- a/ocfweb/main/templates/main/home.html
+++ b/ocfweb/main/templates/main/home.html
@@ -17,7 +17,9 @@
         </div>
         <div class="row">
             <div class="col-sm-8">
+                <br />
                 <p>The Open Computing Facility (OCF) is an all-volunteer student organization dedicated to free computing for all University of California, Berkeley students, faculty, and staff.</p>
+                <p>We're passionate about open source and free software.</p>
                 <p class="ocf-button-holder">
                 <a href="{% url 'about-staff' %}" class="btn btn-lg">Learn what we do</a>
                 <a href="{% url 'register' %}" class="btn btn-lg">Create an account</a>
@@ -34,12 +36,7 @@
 
         {{lab_status.banner_html | safe}}
 
-        <p>
-            The Open Computing Facility is an all-volunteer student
-            organization located at the University of California, Berkeley.
-            We're passionate about open source and free software.
-        </p>
-        <p>Our volunteers maintain services for the Berkeley community. Among others, we offer:</p>
+        <p>OCF volunteers maintain services for the Berkeley community, including:</p>
         <ul>
             <li><a href="{% url 'doc' 'services/lab' %}">A spiffy computer lab</a> in 171 MLK Student Union</li>
             <li><a href="{% url 'doc' 'services/web' %}">Web &amp; email hosting</a> for thousands of student groups and individuals</li>

--- a/ocfweb/static/scss/pages/_home.scss
+++ b/ocfweb/static/scss/pages/_home.scss
@@ -153,6 +153,10 @@
             }
         }
 
+        hr {
+            border-top: 1px solid #777;
+        }
+
         .ocf-button-holder {
             padding-bottom: 10px;
             margin-left: -10px;

--- a/ocfweb/templates/base.html
+++ b/ocfweb/templates/base.html
@@ -101,7 +101,7 @@
             <div class="container">
                 <p>
                     <strong>The OCF supports Black Lives Matter.</strong>
-                    We are matching donations to BLM-related causes, up to $1000.
+                    We are matching donations to BLM-related causes, up to $1000 total.
                     <a class="unsubtle nowrap" href="{% url 'doc' 'communications/blm' %}">read more &raquo;</a>
                 </p>
             </div>


### PR DESCRIPTION
<img width="1277" alt="Screenshot 2020-06-20 at 14 02 47" src="https://user-images.githubusercontent.com/5396448/85208483-e6182200-b2fe-11ea-9b2b-abccc87960db.png">

In addition to the homepage wording changes shown in the screenshot, I also made it say "$1000 total" instead of just "$1000".