### PR TITLE
Update Django to 3.0.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ chardet==3.0.4
 cracklib==2.9.3
 cryptography==2.8
 cycler==0.10.0
-Django==3.0.7
+Django==3.0.8
 django-bootstrap-form==3.4
 django-ipware==2.1.0
 django-mathfilters==0.4.0


### PR DESCRIPTION
It was not fun having 3.0.7 break `make dev` for literally everyone but it fixed a few critical vulnerabilities too.