### PR TITLE
Allocate ptty

### DIFF
--- a/ocfweb/account/commands.py
+++ b/ocfweb/account/commands.py
@@ -44,8 +44,9 @@ def commands(request: HttpRequest) -> HttpResponse:
                 error = 'Authentication failed. Did you type the wrong username or password?'
 
             if not error:
-                _, ssh_stdout, _ = ssh.exec_command(command_to_run, get_pty=True)
+                _, ssh_stdout, ssh_stderr = ssh.exec_command(command_to_run, get_pty=True)
                 output = ssh_stdout.read().decode()
+                error = ssh_stderr.read().decode()
     else:
         form = CommandForm()
 

--- a/ocfweb/account/commands.py
+++ b/ocfweb/account/commands.py
@@ -44,9 +44,8 @@ def commands(request: HttpRequest) -> HttpResponse:
                 error = 'Authentication failed. Did you type the wrong username or password?'
 
             if not error:
-                _, ssh_stdout, ssh_stderr = ssh.exec_command(command_to_run)
+                _, ssh_stdout, _ = ssh.exec_command(command_to_run, get_pty=True)
                 output = ssh_stdout.read().decode()
-                error = ssh_stderr.read().decode()
     else:
         form = CommandForm()
 


### PR DESCRIPTION
Not sure why this is but at some point `makemysql` broke with the following error:

`tee: /dev/tty: No such device or address`

I've not root caused this or figured out when it broke, but a workaround for now is to force paramiko to allocate a pseudo tty using get_pty. This actually also combines stdout and stderr but thats ok for now.