### PR TITLE
Sort the columns in the Today's Lab Utilization table when clicking on table heads

### DIFF
--- a/ocfweb/static/scss/pages/_stats.scss
+++ b/ocfweb/static/scss/pages/_stats.scss
@@ -1,0 +1,1 @@
+@import 'stats/summary';

--- a/ocfweb/static/scss/pages/stats/_summary.scss
+++ b/ocfweb/static/scss/pages/stats/_summary.scss
@@ -1,0 +1,31 @@
+/* Display arrows next to table headers to indicate that clicking on the headers will sort the columns.
+ * Extracted from github.com/Mottie/tablesorter/blob/master/css/theme.default.css, the default theme of tablesorter. */
+.tablesorter-default .header,
+.tablesorter-default .tablesorter-header {
+    background-image: url(data:image/gif;base64,R0lGODlhFQAJAIAAACMtMP///yH5BAEAAAEALAAAAAAVAAkAAAIXjI+AywnaYnhUMoqt3gZXPmVg94yJVQAAOw==);
+    background-position: center right;
+    background-repeat: no-repeat;
+    cursor: pointer;
+    white-space: normal;
+    padding: 4px 20px 4px 4px;
+}
+
+.tablesorter-default thead .headerSortUp,
+.tablesorter-default thead .tablesorter-headerSortUp,
+.tablesorter-default thead .tablesorter-headerAsc {
+    background-image: url(data:image/gif;base64,R0lGODlhFQAEAIAAACMtMP///yH5BAEAAAEALAAAAAAVAAQAAAINjI8Bya2wnINUMopZAQA7);
+    border-bottom: #000 2px solid;
+}
+
+.tablesorter-default thead .headerSortDown,
+.tablesorter-default thead .tablesorter-headerSortDown,
+.tablesorter-default thead .tablesorter-headerDesc {
+    background-image: url(data:image/gif;base64,R0lGODlhFQAEAIAAACMtMP///yH5BAEAAAEALAAAAAAVAAQAAAINjB+gC+jP2ptn0WskLQA7);
+    border-bottom: #000 2px solid;
+}
+
+.tablesorter-default thead .sorter-false {
+    background-image: none;
+    cursor: default;
+    padding: 4px;
+}

--- a/ocfweb/static/scss/site.scss
+++ b/ocfweb/static/scss/site.scss
@@ -292,5 +292,6 @@ h6 {
 @import 'pages/home';
 @import 'pages/login';
 @import 'pages/staff-hours';
+@import 'pages/stats';
 @import 'pages/printing-announcement';
 @import 'pages/tv';

--- a/ocfweb/stats/templates/stats/summary.html
+++ b/ocfweb/stats/templates/stats/summary.html
@@ -75,7 +75,7 @@
     </div>
 {% endblock %}
 
-{% block sortable_lab_utilization %}
+{% block inline_js %}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.31.3/js/jquery.tablesorter.min.js"></script>
 <script>
 $(document).ready(function() {

--- a/ocfweb/stats/templates/stats/summary.html
+++ b/ocfweb/stats/templates/stats/summary.html
@@ -49,24 +49,28 @@
 
         <h3>Today's Lab Utilization</h3>
         <table id="todays-lab-utilization" class="table table-striped table-hover">
-            <tr>
-                <th>Desktop</th>
-                <th>Idle (min)</th>
-                <th>Busy (min)</th>
-                <th>% Busy</th>
-            </tr>
-            {% for profile in desktop_profiles %}
+            <thead>
                 <tr>
-                    <td>{{profile.hostname}}</td>
-                    <td>{{profile.minutes_idle|floatformat:"0"}}</td>
-                    <td>{{profile.minutes_busy|floatformat:"0"}}</td>
-                    {% if profile.total_minutes <= 0 %}
-                        <td>0%</td>
-                    {% else %}
-                        <td>{{profile.minutes_busy|div:profile.total_minutes|mul:100|floatformat:"0"}}%</td>
-                    {% endif %}
+                    <th>Desktop</th>
+                    <th>Idle (min)</th>
+                    <th>Busy (min)</th>
+                    <th>% Busy</th>
                 </tr>
-            {% endfor %}
+            </thead>
+            <tbody>
+                {% for profile in desktop_profiles %}
+                    <tr>
+                        <td>{{profile.hostname}}</td>
+                        <td>{{profile.minutes_idle|floatformat:"0"}}</td>
+                        <td>{{profile.minutes_busy|floatformat:"0"}}</td>
+                        {% if profile.total_minutes <= 0 %}
+                            <td>0%</td>
+                        {% else %}
+                            <td>{{profile.minutes_busy|div:profile.total_minutes|mul:100|floatformat:"0"}}%</td>
+                        {% endif %}
+                    </tr>
+                {% endfor %}
+            </tbody>
         </table>
     </div>
 {% endblock %}

--- a/ocfweb/stats/templates/stats/summary.html
+++ b/ocfweb/stats/templates/stats/summary.html
@@ -78,7 +78,7 @@
 {% block inline_js %}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.31.3/js/jquery.tablesorter.min.js"></script>
 <script>
-$(document).ready(function() {
+$(function() {
     $("#todays-lab-utilization").tablesorter();
   });
 </script>

--- a/ocfweb/stats/templates/stats/summary.html
+++ b/ocfweb/stats/templates/stats/summary.html
@@ -48,7 +48,7 @@
         </div>
 
         <h3>Today's Lab Utilization</h3>
-        <table class="table table-striped table-hover">
+        <table id="todays-lab-utilization" class="table table-striped table-hover">
             <tr>
                 <th>Desktop</th>
                 <th>Idle (min)</th>
@@ -69,4 +69,13 @@
             {% endfor %}
         </table>
     </div>
+{% endblock %}
+
+{% block sortable_lab_utilization %}
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.31.3/js/jquery.tablesorter.min.js"></script>
+<script>
+$(function() {
+    $("#todays-lab-utilization").tablesorter();
+  });
+</script>
 {% endblock %}

--- a/ocfweb/stats/templates/stats/summary.html
+++ b/ocfweb/stats/templates/stats/summary.html
@@ -78,7 +78,7 @@
 {% block sortable_lab_utilization %}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.31.3/js/jquery.tablesorter.min.js"></script>
 <script>
-$(function() {
+$(document).ready(function() {
     $("#todays-lab-utilization").tablesorter();
   });
 </script>


### PR DESCRIPTION
When a table head is clicked (like "% Busy" or "Desktop"), the column will be sorted in ascending order. Click again to sort in descending order. Hold the "Control" key while clicking to reset the column order to default.

A demo is available at [trojan.ocf.berkeley.edu:8794/stats/](http://trojan.ocf.berkeley.edu:8794/stats/). Scroll down and click on the "% Busy" header to see the effect.