### PR TITLE
staff-hours: Fix typo in closing <b> tag

### DIFF
--- a/ocfweb/main/templates/main/staff-hours.html
+++ b/ocfweb/main/templates/main/staff-hours.html
@@ -8,7 +8,7 @@
         <h2>Have questions? Drop by for help from a friendly volunteer staffer!</h2>
         <p>OCF staff members hold regular drop-in staff hours to provide assistance with account issues or with OCF services. We're always happy to help troubleshoot account or service issues!</p>
         <p>Keep in mind the OCF volunteers sometimes have last-minute conflicts, so it's a good idea to check this page for cancellations.</p>
-        <p><b>Staff hours are now online! Click <a href="https://berkeley.zoom.us/j/92953066816">here</a> to join the meeting or use the Zoom meeting ID 929 5306 6816<b></p>
+        <p><b>Staff hours are now online! Click <a href="https://berkeley.zoom.us/j/92953066816">here</a> to join the meeting or use the Zoom meeting ID 929 5306 6816</b></p>
         {% for staff_hour in staff_hours %}
             <div class="hour {% if staff_hour.cancelled or staff_hour.day == today and lab_status.force_lab_closed %} cancelled {% endif %}">
                 <div class="title">


### PR DESCRIPTION
This was causing the entire page after this tag to be bold.