### PR TITLE
Add OCF search domain to ocfweb-static

### DIFF
--- a/kubernetes/ocfweb-static.yaml.erb
+++ b/kubernetes/ocfweb-static.yaml.erb
@@ -51,6 +51,10 @@ spec:
             initialDelaySeconds: 5
             timeoutSeconds: 3
             periodSeconds: 5
+      dnsPolicy: ClusterFirst
+      dnsConfig:
+        searches:
+          - "ocf.berkeley.edu"
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress


### PR DESCRIPTION
This is already present on [`ocfweb-web`](https://github.com/ocf/ocfweb/blob/f277cc3b77e15ae762b70b13c0fe6c3c33655836/kubernetes/ocfweb-web.yaml.erb#L78-L81) and [`ocfweb-worker`](https://github.com/ocf/ocfweb/blob/f277cc3b77e15ae762b70b13c0fe6c3c33655836/kubernetes/ocfweb-worker.yaml.erb#L47-L50) but isn't in `ocfweb-static` for some reason, so we're not getting any logs from it.