### PR TITLE
Remove status bar

### DIFF
--- a/ocfweb/templates/base.html
+++ b/ocfweb/templates/base.html
@@ -97,7 +97,7 @@
             </div>
         </div>
 
-        <div class="ocf-status-bar">
+        <!-- <div class="ocf-status-bar">
             <div class="container">
                 <p>
                     {% if not lab_status.force_lab_closed %}
@@ -120,7 +120,7 @@
                     {% endif %}
                 </p>
             </div>
-        </div>
+        </div> -->
 
         {% block hero %}
             {% if title %}


### PR DESCRIPTION
lab hours are not that useful when the lab is closed all semester. revert this when MLK opens.