### PR TITLE
docs/contact/irc: three options => four options

### DIFF
--- a/ocfweb/docs/docs/contact/irc.md
+++ b/ocfweb/docs/docs/contact/irc.md
@@ -8,7 +8,7 @@ discussion-type questions.
 We normally chat in the `#rebuild` channel. For historical reasons, `#ocf` is
 mostly for non-OCF-related discussion.
 
-You have four simple options for chatting:
+You have a couple of options for chatting:
 
 ### Option 1: Use our web client
 

--- a/ocfweb/docs/docs/contact/irc.md
+++ b/ocfweb/docs/docs/contact/irc.md
@@ -8,7 +8,7 @@ discussion-type questions.
 We normally chat in the `#rebuild` channel. For historical reasons, `#ocf` is
 mostly for non-OCF-related discussion.
 
-You have three simple options for chatting:
+You have four simple options for chatting:
 
 ### Option 1: Use our web client
 


### PR DESCRIPTION
Unless this was some kind of snub against XMPP being simple, we probably
shouldn't say there are "three simple options" and then list four options.