### PR TITLE
Update buster upgrade info

### DIFF
--- a/ocfweb/docs/views/buster_upgrade.py
+++ b/ocfweb/docs/views/buster_upgrade.py
@@ -122,19 +122,11 @@ def _get_servers() -> Tuple[Any, ...]:
         ),
         ThingToUpgrade.from_hostname(
             'segfault',
-            status=ThingToUpgrade.NEEDS_UPGRADE,
-        ),
-        ThingToUpgrade.from_hostname(
-            'whirlwind',
-            status=ThingToUpgrade.NEEDS_UPGRADE,
-        ),
-        ThingToUpgrade.from_hostname(
-            'pileup',
-            status=ThingToUpgrade.NEEDS_UPGRADE,
+            status=ThingToUpgrade.UPGRADED,
         ),
         ThingToUpgrade.from_hostname(
             'monsoon',
-            status=ThingToUpgrade.NEEDS_UPGRADE,
+            status=ThingToUpgrade.UPGRADED,
         ),
         ThingToUpgrade.from_hostname(
             'fraud',
@@ -192,7 +184,7 @@ def _get_servers() -> Tuple[Any, ...]:
         ),
         ThingToUpgrade.from_hostname(
             'corruption',
-            status=ThingToUpgrade.NEEDS_UPGRADE,
+            status=ThingToUpgrade.UPGRADED,
         ),
         ThingToUpgrade.from_hostname(
             'fallingrocks',


### PR DESCRIPTION
HPC is on Buster now, and pileup/whirlwind are offline now (R.I.P.)