### PR TITLE
Remove un-used Metabase iframe for session-stats

### DIFF
--- a/ocfweb/stats/templates/stats/session_stats.html
+++ b/ocfweb/stats/templates/stats/session_stats.html
@@ -9,7 +9,6 @@
 
     <div class="ocf-content-block">
     {% stats_navbar %}
-     <iframe src="https://metabase.ocf.berkeley.edu/public/dashboard/ece8bcde-16d0-42dd-bd66-e8e30f256837" frameborder="0" width="100%" height="2150" allowtransparency></iframe>
 
     <h3>Top Staff by Lab Utilization</h3>
             <div class="row">


### PR DESCRIPTION
I didn't realize that the session stats was just hidden underneath a huge iframe.