### PR TITLE
Add inaccuracy disclaimer

### DIFF
--- a/ocfweb/stats/templates/stats/mirrors.html
+++ b/ocfweb/stats/templates/stats/mirrors.html
@@ -6,7 +6,7 @@
     <div class="ocf-content-block">
       {% stats_navbar %}
       <h2> Bandwidth usage per mirrored project </h2>
-      <h2> Please note that bandwidth statistics prior to 10/11/2021 were inaccurate. </h2>
+      <h2> Please note that bandwidth statistics logged prior to 10/11/2021 were inaccurate. </h2>
       <div class="row">
     <div class="col-md-6">
       <h4> Bandwidth Usage Since {{ start_date }} - {{ semester_total }} total</h4>


### PR DESCRIPTION
https://github.com/ocf/puppet/pull/1171

Previous versions of the collect-mirrors-stats script probably assumed that rsync logs are rotated daily and old logs removed. However, that was no longer the case, and years of rsync traffic are added to the daily total every day, leading to widely inflated traffic statistics.