### PR TITLE
Fix links on staff-hours page

### DIFF
--- a/ocfweb/main/templates/main/staff-hours.html
+++ b/ocfweb/main/templates/main/staff-hours.html
@@ -8,7 +8,7 @@
         <h2>Have questions? Drop by for help from a friendly volunteer staffer!</h2>
         <p>OCF staff members hold regular drop-in staff hours to provide assistance with account issues or with OCF services. We're always happy to help troubleshoot account or service issues!</p>
         <p>Keep in mind the OCF volunteers sometimes have last-minute conflicts, so it's a good idea to check this page for cancellations.</p>
-        <p><b>Staff hours are now in person! Visit <a href="ocf.io/lab">ocf.io/lab</a> for directions. If you need online staff hours, please email help@ocf.berkeley.edu.</b></p>
+        <p><b>Staff hours are now in person! Visit <a href="https://ocf.io/lab">ocf.io/lab</a> for directions. If you need online staff hours, please email <a href="mailto:help@ocf.berkeley.edu">help@ocf.berkeley.edu</a>.</b></p>
         {% for staff_hour in staff_hours %}
             <div class="hour {% if staff_hour.cancelled %} cancelled {% endif %}">
                 <div class="title">


### PR DESCRIPTION
Make ocf.io shortlink absolute and add mailto link for email.
