### PR TITLE
Add endpoints for ocfstatic stats page

### DIFF
--- a/ocfweb/api/stats.py
+++ b/ocfweb/api/stats.py
@@ -3,6 +3,7 @@ from django.http import JsonResponse
 
 from ocfweb.stats.summary import staff_in_lab
 from ocfweb.stats.summary import users_in_lab_count
+from ocfweb.stats.summary import printers
 
 
 def get_num_users_in_lab(request: HttpRequest) -> JsonResponse:
@@ -15,5 +16,11 @@ def get_num_users_in_lab(request: HttpRequest) -> JsonResponse:
 def get_staff_in_lab(request: HttpRequest) -> JsonResponse:
     return JsonResponse(
         staff_in_lab(),
+        safe=False,
+    )
+
+def get_printers_summary(request: HttpRequest) -> JsonResponse:
+    return JsonResponse(
+        printers(),
         safe=False,
     )

--- a/ocfweb/api/stats.py
+++ b/ocfweb/api/stats.py
@@ -1,3 +1,6 @@
+from typing import List
+from typing import Tuple
+
 from django.http import HttpRequest
 from django.http import JsonResponse
 from ocflib.lab.stats import humanize_bytes
@@ -7,7 +10,6 @@ from ocfweb.stats.summary import desktop_profiles
 from ocfweb.stats.summary import printers
 from ocfweb.stats.summary import staff_in_lab
 from ocfweb.stats.summary import users_in_lab_count
-from typing import List, Tuple
 # These endpoints are for ocfstatic stats
 
 

--- a/ocfweb/api/stats.py
+++ b/ocfweb/api/stats.py
@@ -61,7 +61,7 @@ def get_mirrors_showcase(request: HttpRequest) -> JsonResponse:
     """ Return bandwidth for a few mirrors that we showcase on stats page
     In human-readable form, sorted with biggest bandwidth first
     """
-    mirrors_showcase = [['ubuntu', 0], ['debian', 0], ['archlinux', 0]]
+    mirrors_showcase: List[Tuple[str, int]] = [('ubuntu', 0), ('debian', 0), ('archlinux', 0)]
 
     total, by_dist = bandwidth_semester(humanize=False)
 

--- a/ocfweb/api/stats.py
+++ b/ocfweb/api/stats.py
@@ -63,19 +63,22 @@ def get_mirrors_showcase(request: HttpRequest) -> JsonResponse:
     """ Return bandwidth for a few mirrors that we showcase on stats page
     In human-readable form, sorted with biggest bandwidth first
     """
-    mirrors_showcase: List[Tuple[str, int]] = [('ubuntu', 0), ('debian', 0), ('archlinux', 0)]
+
+    mirrors_showcase = ['ubuntu', 'debian', 'archlinux']
 
     total, by_dist = bandwidth_semester(humanize=False)
+    mirrors_showcase_data: List[Tuple[str, int]] = []
 
     for m in mirrors_showcase:
-        bw = 0
-        for dist in by_dist:
-            if dist[0].startswith(m[0]):
-                bw += dist[1]
-        m[1] = bw
-    mirrors_showcase.sort(key=lambda m: m[1], reverse=True)
+        bw_sum = 0
+        for dist, bw in by_dist:
+            if dist.startswith(m):
+                bw_sum += bw
+        mirrors_showcase_data.append((m, bw_sum))
+
+    mirrors_showcase_data.sort(key=lambda m: m[1], reverse=True)
     response = JsonResponse(
-        [[b[0], humanize_bytes(b[1])] for b in mirrors_showcase],
+        [(b[0], humanize_bytes(b[1])) for b in mirrors_showcase_data],
         safe=False,
     )
 

--- a/ocfweb/api/stats.py
+++ b/ocfweb/api/stats.py
@@ -30,7 +30,6 @@ def get_printers_summary(request: HttpRequest) -> JsonResponse:
         printers(),
         safe=False,
     )
-    response['Access-Control-Allow-Origin'] = '*'  # MUST REMOVE THIS
     return response
 
 
@@ -39,10 +38,7 @@ def get_desktop_usage(request: HttpRequest) -> JsonResponse:
     Copy desktop usage from Django API by grabbing class attributes that
     can't be serialized to JSON
     """
-    # responseList = list(desktop_profiles())
-    # responseSet = desktop_profiles()
-    # for i in range(len(responseList)):
-    #     responseList[i] = list(responseList[i])
+
     responseList = []
     for profile in desktop_profiles():
         minutes_idle = profile.minutes_idle
@@ -58,7 +54,6 @@ def get_desktop_usage(request: HttpRequest) -> JsonResponse:
         responseList,
         safe=False,
     )
-    response['Access-Control-Allow-Origin'] = '*'  # MUST REMOVE THIS
     return response
 
 
@@ -67,24 +62,19 @@ def get_mirrors_showcase(request: HttpRequest) -> JsonResponse:
     In human-readable form, sorted with biggest bandwidth first
     """
     mirrors_showcase = [['ubuntu', 0], ['debian', 0], ['archlinux', 0]]
-    # week_ago = datetime.datetime.now() - datetime.timedelta(days=7)
-    # REMOVE THIS-- bandwidth is by semester
 
     total, by_dist = bandwidth_semester(humanize=False)
 
-    for proj in mirrors_showcase:
+    for m in mirrors_showcase:
         bw = 0
         for dist in by_dist:
-            if dist[0].startswith(proj[0]):
+            if dist[0].startswith(m[0]):
                 bw += dist[1]
-        proj[1] = bw
+        m[1] = bw
     mirrors_showcase.sort(key=lambda m: m[1], reverse=True)
     response = JsonResponse(
         [[b[0], humanize_bytes(b[1])] for b in mirrors_showcase],
         safe=False,
     )
-    response['Access-Control-Allow-Origin'] = '*'  # MUST REMOVE THIS
 
     return response
-
-# Idea: Package summary stats together into one function

--- a/ocfweb/api/stats.py
+++ b/ocfweb/api/stats.py
@@ -7,7 +7,7 @@ from ocfweb.stats.summary import desktop_profiles
 from ocfweb.stats.summary import printers
 from ocfweb.stats.summary import staff_in_lab
 from ocfweb.stats.summary import users_in_lab_count
-
+from typing import List, Tuple
 # These endpoints are for ocfstatic stats
 
 

--- a/ocfweb/api/urls.py
+++ b/ocfweb/api/urls.py
@@ -16,6 +16,9 @@ urlpatterns = [
     path('lab/desktops', lab.desktop_usage, name='desktop_usage'),
     path('lab/num_users', stats.get_num_users_in_lab, name='get_num_users_in_lab'),
     path('lab/staff', stats.get_staff_in_lab, name='get_staff_in_lab'),
+    path('lab/printers_summary', stats.get_printers_summary, name='get_printers_summary'),
+    path('lab/desktop_usage', stats.get_desktop_usage, name='get_desktop_usage'),
+    path('lab/mirrors_showcase', stats.get_mirrors_showcase, name='get_mirrors_showcase'),
     path('session/log', session_tracking.log_session, name='log_session'),
     path('shorturl/<path:slug>', shorturls.bounce_shorturl, name='bounce_shorturl'),
 ]

--- a/ocfweb/stats/mirrors.py
+++ b/ocfweb/stats/mirrors.py
@@ -37,7 +37,7 @@ def stats_mirrors(request: HttpRequest) -> HttpResponse:
 
 
 @periodic(86400)
-def bandwidth_semester(humanize=True) -> Tuple[Any, Any]:
+def bandwidth_semester(humanize: bool = True) -> Tuple[Any, Any]:
     if current_semester_start() > MIRRORS_REPORTING_FIXED:
         data = bandwidth_by_dist(current_semester_start())
     else:

--- a/ocfweb/stats/mirrors.py
+++ b/ocfweb/stats/mirrors.py
@@ -37,14 +37,18 @@ def stats_mirrors(request: HttpRequest) -> HttpResponse:
 
 
 @periodic(86400)
-def bandwidth_semester() -> Tuple[Any, Any]:
+def bandwidth_semester(humanize=True) -> Tuple[Any, Any]:
     if current_semester_start() > MIRRORS_REPORTING_FIXED:
         data = bandwidth_by_dist(current_semester_start())
     else:
         data = bandwidth_by_dist(MIRRORS_REPORTING_FIXED)
 
-    total = humanize_bytes(sum(x[1] for x in data))
-    by_dist = [(dist, humanize_bytes(bw)) for dist, bw in data]
+    if humanize:
+        total = humanize_bytes(sum(x[1] for x in data))
+        by_dist = [(dist, humanize_bytes(bw)) for dist, bw in data]
+    else:
+        total = sum(x[1] for x in data)
+        by_dist = [(dist, bw) for dist, bw in data]
 
     return total, by_dist
 


### PR DESCRIPTION
Currently building out ocfstatic stats page. These endpoints are for the summary page and use mostly old ocfweb stuff.

The reasoning behind this is that we can re-use the Django API from the old website (at least for now) and just serve the new static site. 