### PR TITLE
Add meeting hours endpoints

### DIFF
--- a/ocfweb/api/meeting_hours.py
+++ b/ocfweb/api/meeting_hours.py
@@ -1,0 +1,32 @@
+from django.http import HttpRequest
+from django.http import JsonResponse
+
+from ocflib.org.meeting_hours import read_meeting_list
+from ocflib.org.meeting_hours import read_next_meeting
+from ocflib.org.meeting_hours import read_current_meeting
+
+def get_meetings_list(request: HttpRequest) -> JsonResponse:
+    return JsonResponse(
+        [item._asdict() for item in read_meeting_list()],
+        safe=False,
+    )
+
+def get_next_meeting(request: HttpRequest) -> JsonResponse:
+    next_meeting = read_next_meeting()
+    if next_meeting is None:
+        return JsonResponse()
+    
+    return JsonResponse(
+        next_meeting._asdict(),
+        safe=False
+    )
+
+def get_current_meeting(request: HttpRequest) -> JsonResponse:
+    current_meeting = read_current_meeting()
+    if current_meeting is None:
+        return JsonResponse()
+    
+    return JsonResponse(
+        current_meeting._asdict(),
+        safe=False
+    )

--- a/ocfweb/api/meeting_hours.py
+++ b/ocfweb/api/meeting_hours.py
@@ -15,20 +15,26 @@ def get_meetings_list(request: HttpRequest) -> JsonResponse:
 def get_next_meeting(request: HttpRequest) -> JsonResponse:
     next_meeting = read_next_meeting()
     if next_meeting is None:
-        return JsonResponse({}, status=204)
+        return JsonResponse(
+            {}, 
+            status=204,
+        )
 
     return JsonResponse(
         next_meeting._asdict(),
-        safe=False
+        safe=False,
     )
 
 
 def get_current_meeting(request: HttpRequest) -> JsonResponse:
     current_meeting = read_current_meeting()
     if current_meeting is None:
-        return JsonResponse({}, status=204)
+        return JsonResponse(
+            {}, 
+            status=204,
+        )
 
     return JsonResponse(
         current_meeting._asdict(),
-        safe=False
+        safe=False,
     )

--- a/ocfweb/api/meeting_hours.py
+++ b/ocfweb/api/meeting_hours.py
@@ -9,7 +9,7 @@ def get_meetings_list(request: HttpRequest) -> JsonResponse:
     return JsonResponse(
         [item._asdict() for item in read_meeting_list()],
         safe=False,
-    ) 
+    )
 
 
 def get_next_meeting(request: HttpRequest) -> JsonResponse:

--- a/ocfweb/api/meeting_hours.py
+++ b/ocfweb/api/meeting_hours.py
@@ -1,9 +1,9 @@
 from django.http import HttpRequest
 from django.http import JsonResponse
-
+from ocflib.org.meeting_hours import read_current_meeting
 from ocflib.org.meeting_hours import read_meeting_list
 from ocflib.org.meeting_hours import read_next_meeting
-from ocflib.org.meeting_hours import read_current_meeting
+
 
 def get_meetings_list(request: HttpRequest) -> JsonResponse:
     return JsonResponse(
@@ -11,21 +11,23 @@ def get_meetings_list(request: HttpRequest) -> JsonResponse:
         safe=False,
     )
 
+
 def get_next_meeting(request: HttpRequest) -> JsonResponse:
     next_meeting = read_next_meeting()
     if next_meeting is None:
         return JsonResponse({})
-    
+
     return JsonResponse(
         next_meeting._asdict(),
         safe=False
     )
 
+
 def get_current_meeting(request: HttpRequest) -> JsonResponse:
     current_meeting = read_current_meeting()
     if current_meeting is None:
         return JsonResponse({})
-    
+
     return JsonResponse(
         current_meeting._asdict(),
         safe=False

--- a/ocfweb/api/meeting_hours.py
+++ b/ocfweb/api/meeting_hours.py
@@ -15,7 +15,7 @@ def get_meetings_list(request: HttpRequest) -> JsonResponse:
 def get_next_meeting(request: HttpRequest) -> JsonResponse:
     next_meeting = read_next_meeting()
     if next_meeting is None:
-        return JsonResponse({})
+        return JsonResponse({}, status=204)
 
     return JsonResponse(
         next_meeting._asdict(),
@@ -26,7 +26,7 @@ def get_next_meeting(request: HttpRequest) -> JsonResponse:
 def get_current_meeting(request: HttpRequest) -> JsonResponse:
     current_meeting = read_current_meeting()
     if current_meeting is None:
-        return JsonResponse({})
+        return JsonResponse({}, status=204)
 
     return JsonResponse(
         current_meeting._asdict(),

--- a/ocfweb/api/meeting_hours.py
+++ b/ocfweb/api/meeting_hours.py
@@ -16,7 +16,7 @@ def get_next_meeting(request: HttpRequest) -> JsonResponse:
     next_meeting = read_next_meeting()
     if next_meeting is None:
         return JsonResponse(
-            {}, 
+            {},
             status=204,
         )
 
@@ -30,7 +30,7 @@ def get_current_meeting(request: HttpRequest) -> JsonResponse:
     current_meeting = read_current_meeting()
     if current_meeting is None:
         return JsonResponse(
-            {}, 
+            {},
             status=204,
         )
 

--- a/ocfweb/api/meeting_hours.py
+++ b/ocfweb/api/meeting_hours.py
@@ -14,7 +14,7 @@ def get_meetings_list(request: HttpRequest) -> JsonResponse:
 def get_next_meeting(request: HttpRequest) -> JsonResponse:
     next_meeting = read_next_meeting()
     if next_meeting is None:
-        return JsonResponse()
+        return JsonResponse({})
     
     return JsonResponse(
         next_meeting._asdict(),
@@ -24,7 +24,7 @@ def get_next_meeting(request: HttpRequest) -> JsonResponse:
 def get_current_meeting(request: HttpRequest) -> JsonResponse:
     current_meeting = read_current_meeting()
     if current_meeting is None:
-        return JsonResponse()
+        return JsonResponse({})
     
     return JsonResponse(
         current_meeting._asdict(),

--- a/ocfweb/api/meeting_hours.py
+++ b/ocfweb/api/meeting_hours.py
@@ -9,7 +9,7 @@ def get_meetings_list(request: HttpRequest) -> JsonResponse:
     return JsonResponse(
         [item._asdict() for item in read_meeting_list()],
         safe=False,
-    )
+    ) 
 
 
 def get_next_meeting(request: HttpRequest) -> JsonResponse:

--- a/ocfweb/api/urls.py
+++ b/ocfweb/api/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from ocfweb.api import announce
 from ocfweb.api import hours
 from ocfweb.api import lab
+from ocfweb.api import meeting_hours
 from ocfweb.api import session_tracking
 from ocfweb.api import shorturls
 from ocfweb.api import staff_hours
@@ -16,6 +17,9 @@ urlpatterns = [
     path('lab/desktops', lab.desktop_usage, name='desktop_usage'),
     path('lab/num_users', stats.get_num_users_in_lab, name='get_num_users_in_lab'),
     path('lab/staff', stats.get_staff_in_lab, name='get_staff_in_lab'),
+    path('meetings/current', meeting_hours.get_current_meeting, name='current_meeting'),
+    path('meetings/next', meeting_hours.get_next_meeting, name='next_meeting'),
+    path('meetings/list', meeting_hours.get_meetings_list, name='meetings_list'),
     path('session/log', session_tracking.log_session, name='log_session'),
     path('shorturl/<path:slug>', shorturls.bounce_shorturl, name='bounce_shorturl'),
 ]


### PR DESCRIPTION
Adds endpoints to the newly-added meeting hours methods from ocflib. These methods will allows public access to an API that returns a list of weekly meetings, the next meeting, and the current meeting (if one is happening at the time). The corresponding ocflib pr can be reviewed [here.](https://github.com/ocf/ocflib/pull/238)