### PR TITLE
Fix meeting-hours caching

### DIFF
--- a/ocfweb/api/meeting_hours.py
+++ b/ocfweb/api/meeting_hours.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Any, List
 from django.http import HttpRequest
 from django.http import JsonResponse
 from ocflib.org.meeting_hours import read_current_meeting
@@ -43,15 +43,15 @@ def get_current_meeting(request: HttpRequest) -> JsonResponse:
     )
 
 
-def _read_meeting_list() -> List:
+def _read_meeting_list() -> List[Any]:
     return read_meeting_list()
 
 
 @periodic(5)
-def _read_next_meeting() -> List:
+def _read_next_meeting() -> List[Any]:
     return read_next_meeting()
 
 
 @periodic(5)
-def _read_current_meeting() -> List:
+def _read_current_meeting() -> List[Any]:
     return read_current_meeting()

--- a/ocfweb/api/meeting_hours.py
+++ b/ocfweb/api/meeting_hours.py
@@ -14,7 +14,7 @@ def get_meetings_list(request: HttpRequest) -> JsonResponse:
     )
 
 
-@periodic(60)
+@periodic(30)
 def get_next_meeting(request: HttpRequest) -> JsonResponse:
     next_meeting = read_next_meeting()
     if next_meeting is None:
@@ -29,7 +29,7 @@ def get_next_meeting(request: HttpRequest) -> JsonResponse:
     )
 
 
-@periodic(60)
+@periodic(30)
 def get_current_meeting(request: HttpRequest) -> JsonResponse:
     current_meeting = read_current_meeting()
     if current_meeting is None:

--- a/ocfweb/api/meeting_hours.py
+++ b/ocfweb/api/meeting_hours.py
@@ -1,4 +1,6 @@
-from typing import Any, List
+from typing import Any
+from typing import List
+
 from django.http import HttpRequest
 from django.http import JsonResponse
 from ocflib.org.meeting_hours import read_current_meeting

--- a/ocfweb/api/meeting_hours.py
+++ b/ocfweb/api/meeting_hours.py
@@ -1,3 +1,4 @@
+from typing import List
 from django.http import HttpRequest
 from django.http import JsonResponse
 from ocflib.org.meeting_hours import read_current_meeting
@@ -42,15 +43,15 @@ def get_current_meeting(request: HttpRequest) -> JsonResponse:
     )
 
 
-def _read_meeting_list() -> list:
+def _read_meeting_list() -> List:
     return read_meeting_list()
 
 
 @periodic(5)
-def _read_next_meeting() -> list:
+def _read_next_meeting() -> List:
     return read_next_meeting()
 
 
 @periodic(5)
-def _read_current_meeting() -> list:
+def _read_current_meeting() -> List:
     return read_current_meeting()

--- a/ocfweb/api/meeting_hours.py
+++ b/ocfweb/api/meeting_hours.py
@@ -1,5 +1,6 @@
 from django.http import HttpRequest
 from django.http import JsonResponse
+from django.views.decorators.cache import never_cache
 from ocflib.org.meeting_hours import read_current_meeting
 from ocflib.org.meeting_hours import read_meeting_list
 from ocflib.org.meeting_hours import read_next_meeting
@@ -12,6 +13,7 @@ def get_meetings_list(request: HttpRequest) -> JsonResponse:
     )
 
 
+@never_cache
 def get_next_meeting(request: HttpRequest) -> JsonResponse:
     next_meeting = read_next_meeting()
     if next_meeting is None:
@@ -26,6 +28,7 @@ def get_next_meeting(request: HttpRequest) -> JsonResponse:
     )
 
 
+@never_cache
 def get_current_meeting(request: HttpRequest) -> JsonResponse:
     current_meeting = read_current_meeting()
     if current_meeting is None:

--- a/ocfweb/api/meeting_hours.py
+++ b/ocfweb/api/meeting_hours.py
@@ -1,9 +1,10 @@
 from django.http import HttpRequest
 from django.http import JsonResponse
-from django.views.decorators.cache import never_cache
 from ocflib.org.meeting_hours import read_current_meeting
 from ocflib.org.meeting_hours import read_meeting_list
 from ocflib.org.meeting_hours import read_next_meeting
+
+from ocfweb.caching import periodic
 
 
 def get_meetings_list(request: HttpRequest) -> JsonResponse:
@@ -13,7 +14,7 @@ def get_meetings_list(request: HttpRequest) -> JsonResponse:
     )
 
 
-@never_cache
+@periodic(60)
 def get_next_meeting(request: HttpRequest) -> JsonResponse:
     next_meeting = read_next_meeting()
     if next_meeting is None:
@@ -28,7 +29,7 @@ def get_next_meeting(request: HttpRequest) -> JsonResponse:
     )
 
 
-@never_cache
+@periodic(60)
 def get_current_meeting(request: HttpRequest) -> JsonResponse:
     current_meeting = read_current_meeting()
     if current_meeting is None:

--- a/ocfweb/api/meeting_hours.py
+++ b/ocfweb/api/meeting_hours.py
@@ -9,14 +9,13 @@ from ocfweb.caching import periodic
 
 def get_meetings_list(request: HttpRequest) -> JsonResponse:
     return JsonResponse(
-        [item._asdict() for item in read_meeting_list()],
+        [item._asdict() for item in _read_meeting_list()],
         safe=False,
     )
 
 
-@periodic(30)
 def get_next_meeting(request: HttpRequest) -> JsonResponse:
-    next_meeting = read_next_meeting()
+    next_meeting = _read_next_meeting()
     if next_meeting is None:
         return JsonResponse(
             {},
@@ -29,9 +28,8 @@ def get_next_meeting(request: HttpRequest) -> JsonResponse:
     )
 
 
-@periodic(30)
 def get_current_meeting(request: HttpRequest) -> JsonResponse:
-    current_meeting = read_current_meeting()
+    current_meeting = _read_current_meeting()
     if current_meeting is None:
         return JsonResponse(
             {},
@@ -42,3 +40,17 @@ def get_current_meeting(request: HttpRequest) -> JsonResponse:
         current_meeting._asdict(),
         safe=False,
     )
+
+
+def _read_meeting_list() -> list:
+    return read_meeting_list()
+
+
+@periodic(5)
+def _read_next_meeting() -> list:
+    return read_next_meeting()
+
+
+@periodic(5)
+def _read_current_meeting() -> list:
+    return read_current_meeting()


### PR DESCRIPTION
The meeting hours API has some endpoints that are time sensitive (`/api/meetings/current`, `/api/meetings/next`) that were previously cached for a long time, meaning the API would return out-of-date results for both of these. This pr fixes that by using a 5-second periodic call, which is also the method the computer availability API uses.

The endpoint `/api/meetings/list` is not affected by this change.