### PR TITLE
Add vhost hostmaster questions

### DIFF
--- a/ocfweb/account/templates/account/vhost/index.html
+++ b/ocfweb/account/templates/account/vhost/index.html
@@ -69,12 +69,15 @@
                 {{form.website_ocf_banner|bootstrap}}
                 {{form.website_disclaimer_text|bootstrap}}
                 {{form.website_updated_software|bootstrap}}
+                {{form.website_hostmaster_policy|bootstrap}}
 
                 {% if is_group %}
                     {{form.your_name|bootstrap}}
                 {% endif %}
-                {{form.your_email|bootstrap}}
                 {{form.your_position|bootstrap}}
+                {{form.your_email|bootstrap}}
+                {{form.university_contact|bootstrap}}
+                {{form.university_purpose|bootstrap}}
                 {{form.comments|bootstrap}}
 
                 <hr />

--- a/ocfweb/account/vhost.py
+++ b/ocfweb/account/vhost.py
@@ -253,10 +253,10 @@ class VirtualHostForm(Form):
     university_purpose = forms.CharField(
         widget=forms.Textarea(attrs={'cols': 60, 'rows': 3}),
         label='The purpose of your requested subdomain, who will be using it,\
-               and its relationship to the university\'s mission.',
+               and its relationship to the university\'s mission:',
         required=False,
         min_length=1,
-        max_length=1024,
+        max_length=2048,
     )
 
     comments = forms.CharField(

--- a/ocfweb/account/vhost.py
+++ b/ocfweb/account/vhost.py
@@ -67,6 +67,8 @@ def request_vhost(request: HttpRequest) -> HttpResponse:
 
         if form.is_valid():
             requested_subdomain = form.cleaned_data['requested_subdomain']
+            university_purpose = form.cleaned_data['university_purpose']
+            university_contact = form.cleaned_data['university_contact']
             comments = form.cleaned_data['comments']
             your_name = form.cleaned_data['your_name'] if is_group else attrs['cn'][0]
             your_email = form.cleaned_data['your_email']
@@ -92,6 +94,10 @@ def request_vhost(request: HttpRequest) -> HttpResponse:
                       - Requested Subdomain: {requested_subdomain}
                       - Current URL: https://www.ocf.berkeley.edu/~{user}/
 
+                    University Hostmaster Questions:
+                      - Purpose: {university_purpose}
+                      - Contact: {university_contact}
+
                     Comments/Special Requests:
                     {comments}
 
@@ -108,6 +114,8 @@ def request_vhost(request: HttpRequest) -> HttpResponse:
                     user=user,
                     title=attrs['cn'][0],
                     requested_subdomain=requested_subdomain,
+                    university_purpose=university_purpose,
+                    university_contact=university_contact,
                     comments=comments,
                     your_name=your_name,
                     your_position=your_position,
@@ -216,16 +224,39 @@ class VirtualHostForm(Form):
                this box and move on.)',
     )
 
-    your_email = forms.EmailField(
-        label='Your email address:',
-        min_length=1,
-        max_length=64,
+    # required disclaimer by the university hostmaster
+    website_hostmaster_policy = forms.BooleanField(
+        label='You acknowledge that all relevant university \
+               policies will be followed, including those pertaining \
+               to <a href="https://dac.berkeley.edu/web-accessibility">\
+               campus website accessibility</a>'
     )
 
     # also see __init__
     your_position = forms.CharField(
         min_length=1,
         max_length=64,
+    )
+
+    your_email = forms.EmailField(
+        label='Your email address:',
+        min_length=1,
+        max_length=64,
+    )
+
+    university_contact = forms.EmailField(
+        label='Contact email address for the university (may be the same as your email):',
+        min_length=1,
+        max_length=64,
+    )
+
+    university_purpose = forms.CharField(
+        widget=forms.Textarea(attrs={'cols': 60, 'rows': 3}),
+        label='The purpose of your requested subdomain, who will be using it,\
+               and its relationship to the university\'s mission.',
+        required=False,
+        min_length=1,
+        max_length=1024,
     )
 
     comments = forms.CharField(

--- a/ocfweb/account/vhost.py
+++ b/ocfweb/account/vhost.py
@@ -229,7 +229,7 @@ class VirtualHostForm(Form):
         label='You acknowledge that all relevant university \
                policies will be followed, including those pertaining \
                to <a href="https://dac.berkeley.edu/web-accessibility">\
-               campus website accessibility</a>'
+               campus website accessibility</a>',
     )
 
     # also see __init__

--- a/ocfweb/docs/docs/staff/procedures/vhost.md
+++ b/ocfweb/docs/docs/staff/procedures/vhost.md
@@ -48,7 +48,7 @@ hostmaster][campus-hostmistress]:
 Use the domain requested by the group in place of `hostname`. We have a
 [reusable email
 template](https://templates.ocf.berkeley.edu/#hostmaster-new-domain) for making
-new DNS requests. This email should be sent to hostmaster@nic.berkeley.edu 
+new DNS requests. This email should be sent to hostmaster@nic.berkeley.edu
 and sm+vhost@ocf.berkeley.edu.
 
 Answers to the following questions (provided by the requestor of the subdomain)
@@ -58,7 +58,7 @@ should be sent to the University hostmaster along with the DNS request itself.
 2. A responsible contact for the hostname
 
 3. Acknowledgment that all relevant university policies will be followed, including those pertaining to [campus website accessibility][campus-accessibility]
-    
+
 
 ### Mail (if requested)    {mail}
 

--- a/ocfweb/docs/docs/staff/procedures/vhost.md
+++ b/ocfweb/docs/docs/staff/procedures/vhost.md
@@ -48,7 +48,17 @@ hostmaster][campus-hostmistress]:
 Use the domain requested by the group in place of `hostname`. We have a
 [reusable email
 template](https://templates.ocf.berkeley.edu/#hostmaster-new-domain) for making
-new DNS requests.
+new DNS requests. This email should be sent to hostmaster@nic.berkeley.edu 
+and sm+vhost@ocf.berkeley.edu.
+
+Answers to the following questions (provided by the requestor of the subdomain)
+should be sent to the University hostmaster along with the DNS request itself.
+1. The purpose of the hostname, who will be using it, and its relationship to the university's mission
+
+2. A responsible contact for the hostname
+
+3. Acknowledgment that all relevant university policies will be followed, including those pertaining to [campus website accessibility][campus-accessibility]
+    
 
 ### Mail (if requested)    {mail}
 
@@ -81,6 +91,8 @@ We have a
 [reusable email
 template](https://templates.ocf.berkeley.edu/#hostmaster-add-mail) for making
 DNS mail requests for groups that have old `CNAME` records.
+
+Mail virtual hosting may be requested separately from website virtual hosting and without a completely developed website.
 
 
 ### Application hosting
@@ -126,3 +138,4 @@ apphost is configured properly, and a `403 Forbidden` otherwise.
 
 [ocf-etc]: https://github.com/ocf/etc
 [campus-hostmistress]: https://ucb.service-now.com/kb_view.do?sysparm_article=KBT0012470
+[campus-accessibility]: https://dac.berkeley.edu/web-accessibility


### PR DESCRIPTION
The university hostmaster now requires answers to the following questions before approving a virtual host domain. I have updated all relevant documentation.

1. The purpose of the hostname, who will be using it and its relationship to the university's mission.
2. A responsible contact for the hostname.
3. Acknowledgment that all relevant university policies will be followed, including those pertaining to campus website accessibility. Those can be found here: https://dac.berkeley.edu/web-accessibility

(source: hostmaster ticket RITM0086801)