### PR TITLE
Fix hostmaster link on vhost form

### DIFF
--- a/ocfweb/account/vhost.py
+++ b/ocfweb/account/vhost.py
@@ -225,12 +225,7 @@ class VirtualHostForm(Form):
     )
 
     # required disclaimer by the university hostmaster
-    website_hostmaster_policy = forms.BooleanField(
-        label='You acknowledge that all relevant university \
-               policies will be followed, including those pertaining \
-               to <a href="https://dac.berkeley.edu/web-accessibility">\
-               campus website accessibility</a>',
-    )
+    website_hostmaster_policy = forms.BooleanField()
 
     # also see __init__
     your_position = forms.CharField(
@@ -286,6 +281,13 @@ class VirtualHostForm(Form):
             'visible on the home page.'
         ).format(reverse('doc', args=('services/vhost/badges',))))
 
+        self.fields['website_hostmaster_policy'].label = mark_safe(
+            'You acknowledge that all relevant university '
+            'policies will be followed, including those pertaining '
+            'to <a href="https://dac.berkeley.edu/web-accessibility"> '
+            'campus website accessibility.</a>'
+        )
+    
         # These just require some runtime info
         self.fields['your_position'].label = mark_safe(
             'Your position in group:' if is_group else 'Your academic post:',

--- a/ocfweb/account/vhost.py
+++ b/ocfweb/account/vhost.py
@@ -285,9 +285,9 @@ class VirtualHostForm(Form):
             'You acknowledge that all relevant university '
             'policies will be followed, including those pertaining '
             'to <a href="https://dac.berkeley.edu/web-accessibility"> '
-            'campus website accessibility.</a>'
+            'campus website accessibility.</a>',
         )
-    
+
         # These just require some runtime info
         self.fields['your_position'].label = mark_safe(
             'Your position in group:' if is_group else 'Your academic post:',

--- a/ocfweb/account/vhost.py
+++ b/ocfweb/account/vhost.py
@@ -285,7 +285,7 @@ class VirtualHostForm(Form):
             'You acknowledge that all relevant university '
             'policies will be followed, including those pertaining '
             'to <a href="https://dac.berkeley.edu/web-accessibility"> '
-            'campus website accessibility.</a>',
+            'campus website accessibility</a>.',
         )
 
         # These just require some runtime info


### PR DESCRIPTION
I did a small oops and initialized the `href` in the wrong place, so it looks like the below. This PR moves the initialization of the label to the correct location. See #767.