### PR TITLE
Add NixOS Desktop Upgrade Tracker and Staff URL

### DIFF
--- a/ocfweb/docs/templates/docs/desktop_upgrade.html
+++ b/ocfweb/docs/templates/docs/desktop_upgrade.html
@@ -1,0 +1,43 @@
+{% extends 'base.html' %}
+
+{% block content %}
+    <div class="ocf-content-block">
+        <p>
+            This table lists all desktops and whether they have been upgraded to NixOS.
+        </p>
+
+    </div>
+
+    <table class="table">
+        {% for server in servers %}
+            <tr {% if server.status == upgraded %}
+                style="background-color: #d3ffd3;"
+              {% elif server.status == blocked %}
+                style="background-color: #ffd3d3;"
+              {% endif %}>
+                <th>
+                    {{server.host.hostname}}
+                    {% if server.has_dev %}
+                        <br />
+                        dev-{{server.host.hostname}}
+                    {% endif %}
+                </th>
+                <td>
+                    {{server.host.description}}
+                    {% if server.comments %}
+                        <div style="background-color: #fffed3;">
+                            <strong>Comments:</strong> {{server.comments}}
+                        </div>
+                    {% endif %}
+                </td>
+                <th>
+                    {% if server.status == upgraded %}
+                        Done!
+                    {% elif server.status == blocked %}
+                        Blocked
+                    {% endif %}
+                </th>
+            </tr>
+        {% endfor %}
+    </table>
+{% endblock %}

--- a/ocfweb/docs/urls.py
+++ b/ocfweb/docs/urls.py
@@ -31,7 +31,7 @@ DOCS = {
             Document(name='/about/officers', title='Officers', render=officers),
             Document(name='/staff/backend/servers', title='Servers', render=servers),
             Document(name='/staff/backend/buster', title='Debian Buster upgrade', render=buster_upgrade),
-            Document(name='/staff/backend/buster', title='Debian Buster upgrade', render=buster_upgrade),
+            Document(name='/staff/backend/nixos', title='NixOS upgrade', render=desktop_upgrade),
             Document(name='/services/account/account-policies', title='Account policies', render=account_policies),
             Document(name='/services/vhost/badges', title='Hosting badges', render=hosting_badges),
             Document(name='/services/lab', title='Computer lab', render=lab),

--- a/ocfweb/docs/views/desktop_upgrade.py
+++ b/ocfweb/docs/views/desktop_upgrade.py
@@ -1,0 +1,199 @@
+'''
+STATUS EXAMPLE
+- Follow the formats to list the desktop
+
+* For a desktop thats not upgraded yet.
+        ThingToUpgrade.from_hostname(
+            'death',
+            comments='same time as all login servers',
+            status=ThingToUpgrade.NEEDS_UPGRADE,
+        ),
+
+* For a desktop that has been upgraded.
+        ThingToUpgrade.from_hostname(
+            'maelstrom',
+            comments="Scanner",
+            status=ThingToUpgrade.UPGRADED,
+        ),
+
+*  For a desktop that has been blocked from upgrading.
+        ThingToUpgrade.from_hostname(
+            'venom',
+            status=ThingToUpgrade.BLOCKED,
+        ),
+
+'''
+from collections import namedtuple
+from typing import Any
+from typing import Optional
+from typing import Tuple
+
+from django.http import HttpRequest
+from django.http import HttpResponse
+from django.shortcuts import render
+from ocflib.misc.validators import host_exists
+
+from ocfweb.caching import cache
+from ocfweb.docs.doc import Document
+from ocfweb.docs.views.servers import Host
+
+
+class ThingToUpgrade(
+    namedtuple(
+        'ThingToUpgrade', (
+            'host',
+            'status',
+            'comments',
+            'has_dev',
+        ),
+    ),
+):
+    NEEDS_UPGRADE = 1
+    BLOCKED = 2
+    UPGRADED = 3
+
+    @classmethod
+    def from_hostname(cls: Any, hostname: str, status: int = NEEDS_UPGRADE, comments: Optional[str] = None) -> Any:
+        has_dev = host_exists('dev-' + hostname + '.ocf.berkeley.edu')
+        return cls(
+            host=Host.from_ldap(hostname),
+            status=status,
+            has_dev=has_dev,
+            comments=comments,
+        )
+
+
+@cache()
+def _get_servers() -> Tuple[Any, ...]:
+    return (
+        # Desktops
+        ThingToUpgrade.from_hostname(
+            'bandit',
+            status=ThingToUpgrade.UPGRADED,
+        ),
+        ThingToUpgrade.from_hostname(
+            'blight',
+            comments='Old PC',
+            status=ThingToUpgrade.NEEDS_UPGRADE,
+        ),
+        ThingToUpgrade.from_hostname(
+            'bolt',
+            status=ThingToUpgrade.UPGRADED,
+        ),
+        ThingToUpgrade.from_hostname(
+            'callie',
+            status=ThingToUpgrade.UPGRADED,
+        ),
+        ThingToUpgrade.from_hostname(
+            'chaos',
+            comments='Scanner',
+            status=ThingToUpgrade.NEEDS_UPGRADE,
+        ),
+        ThingToUpgrade.from_hostname(
+            'cyanide',
+            comments='Old PC',
+            status=ThingToUpgrade.NEEDS_UPGRADE,
+        ),
+        ThingToUpgrade.from_hostname(
+            'drought',
+            comments='Old PC',
+            status=ThingToUpgrade.NEEDS_UPGRADE,
+        ),
+        ThingToUpgrade.from_hostname(
+            'fred',
+            status=ThingToUpgrade.UPGRADED,
+        ),
+        ThingToUpgrade.from_hostname(
+            'gabriel',
+            status=ThingToUpgrade.UPGRADED,
+        ),
+        ThingToUpgrade.from_hostname(
+            'hailstorm',
+            comments='Old PC',
+            status=ThingToUpgrade.NEEDS_UPGRADE,
+        ),
+        ThingToUpgrade.from_hostname(
+            'heatwave',
+            comments='Old PC',
+            status=ThingToUpgrade.NEEDS_UPGRADE,
+        ),
+        ThingToUpgrade.from_hostname(
+            'lexy',
+            status=ThingToUpgrade.UPGRADED,
+        ),
+        ThingToUpgrade.from_hostname(
+            'madcow',
+            comments='Old PC',
+            status=ThingToUpgrade.NEEDS_UPGRADE,
+        ),
+        ThingToUpgrade.from_hostname(
+            'maelstrom',
+            comments='Scanner',
+            status=ThingToUpgrade.NEEDS_UPGRADE,
+        ),
+        ThingToUpgrade.from_hostname(
+            'misty',
+            status=ThingToUpgrade.UPGRADED,
+        ),
+        ThingToUpgrade.from_hostname(
+            'pickles',
+            status=ThingToUpgrade.UPGRADED,
+        ),
+        ThingToUpgrade.from_hostname(
+            'pumpkin',
+            status=ThingToUpgrade.UPGRADED,
+        ),
+        ThingToUpgrade.from_hostname(
+            'shadow',
+            status=ThingToUpgrade.UPGRADED,
+        ),
+        ThingToUpgrade.from_hostname(
+            'smokey',
+            status=ThingToUpgrade.UPGRADED,
+        ),
+        ThingToUpgrade.from_hostname(
+            'socks',
+            status=ThingToUpgrade.UPGRADED,
+        ),
+        ThingToUpgrade.from_hostname(
+            'spots',
+            status=ThingToUpgrade.UPGRADED,
+        ),
+        ThingToUpgrade.from_hostname(
+            'sunny',
+            comments='Old PC',
+            status=ThingToUpgrade.NEEDS_UPGRADE,
+        ),
+        ThingToUpgrade.from_hostname(
+            'surge',
+            comments='Scanner',
+            status=ThingToUpgrade.NEEDS_UPGRADE,
+        ),
+        ThingToUpgrade.from_hostname(
+            'tabitha',
+            status=ThingToUpgrade.UPGRADED,
+        ),
+        ThingToUpgrade.from_hostname(
+            'venom',
+            comments='Old PC',
+            status=ThingToUpgrade.NEEDS_UPGRADE,
+        ),
+        ThingToUpgrade.from_hostname(
+            'volcano',
+            comments='Old PC',
+            status=ThingToUpgrade.NEEDS_UPGRADE,
+        ),
+    )
+
+
+def desktop_upgrade(doc: Document, request: HttpRequest) -> HttpResponse:
+    return render(
+        request,
+        'docs/desktop_upgrade.html',
+        {
+            'title': doc.title,
+            'servers': _get_servers(),
+            'blocked': ThingToUpgrade.BLOCKED,
+            'upgraded': ThingToUpgrade.UPGRADED,
+        },
+    )


### PR DESCRIPTION
Added 2 files and modified 1:

desktop_upgrade.html and desktop_upgrade.py are effectively copies of previous Debian Buster upgrade pages, renewed to feature desktop names instead of server names and the current status at the time of this PR.

urls.py was modified to include these new pages so that they can be accessed from /docs/staff.

The fork passed all the tests outlined in the README.md.