### PR TITLE
remove lab ID card requirement

### DIFF
--- a/ocfweb/docs/templates/docs/lab.html
+++ b/ocfweb/docs/templates/docs/lab.html
@@ -40,10 +40,6 @@
                     It can be accessed through the main MLK building or via the
                     tunnel by the stairs between Upper and Lower Sproul.
                 </p>
-                <p>
-                    To enter the lab, bring a valid student identification card; you
-                    will be asked to show it.
-                </p>
                 <div class="ocf-content-block">
                     <p>{% google_map '100%' '300px' %}</p>
                 </div>


### PR DESCRIPTION
removed "To enter the lab, bring a valid student identification card; you will be asked to show it." from computer lab page