### PR TITLE
Fix virtual host request domain length limit

### DIFF
--- a/ocfweb/account/vhost.py
+++ b/ocfweb/account/vhost.py
@@ -218,7 +218,7 @@ class VirtualHostForm(Form):
     requested_subdomain = forms.CharField(
         label='Requested domain:',
         min_length=1,
-        max_length=32,
+        max_length=63 + len('.studentorg.berkeley.edu'),
         widget=forms.TextInput(attrs={'placeholder': 'mysite.studentorg.berkeley.edu'}),
     )
 


### PR DESCRIPTION
The virtual-host request form rejects domains longer than 32 characters, preventing student groups with longer names from requesting hosting.

Set the field limit to a 63-character label plus `.studentorg.berkeley.edu` (87 characters total). Django applies the limit to both server-side field validation and the HTML input's `maxlength`.

Closes #905.

Validation: evaluated the actual field declaration with Django 5.2.5 in isolation: 33-, 64-, and 87-character domains pass, 88 characters fail, and the widget exposes `maxlength="87"`. The original 32-character limit rejects the same 33-character example. Flake8 and `git diff --check` pass. The full OCF website test suite was not run locally; this validation isolates the field from OCF service dependencies.
